### PR TITLE
Describe how to deploy the cluster-api stack with minikuber + KVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,77 @@ by the RH's docker fork (see [https://github.com/kubernetes-sigs/kubebuilder/iss
 One needs to run the `imagebuilder` command instead of the `docker build`.
 
 Note: this info is RH only, it needs to be backported every time the `README.md` is synced with the upstream one.
+
+## How to deploy and test the machine controller with minikube
+
+1. **Install kvm**
+
+    Depending on your virtualization manager you can choose a different [driver](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md).
+    In order to install kvm, you can run (as described in the [drivers](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#kvm2-driver) documentation):
+
+    ```sh
+    $ sudo yum install libvirt-daemon-kvm qemu-kvm libvirt-daemon-config-network
+    $ systemctl start libvirtd
+    $ sudo usermod -a -G libvirt $(whoami)
+    $ newgrp libvirt
+    ```
+
+    To install to kvm2 driver:
+
+    ```sh
+    curl -Lo docker-machine-driver-kvm2 https://storage.googleapis.com/minikube/releases/latest/docker-machine-driver-kvm2 \
+    && chmod +x docker-machine-driver-kvm2 \
+    && sudo cp docker-machine-driver-kvm2 /usr/local/bin/ \
+    && rm docker-machine-driver-kvm2
+    ```
+
+2. **Deploying the cluster**
+
+    Because of [cluster-api#475](https://github.com/kubernetes-sigs/cluster-api/issues/475) the minikube version can't be higher than `0.28.0`.
+    To install minikube `v0.28.0`, you can run:
+
+    ```sg
+    $ curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.28.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+    ```
+
+    To deploy the cluster:
+
+    ```
+    minikube start --vm-driver kvm2
+    eval $(minikube docker-env)
+    ```
+
+3. **Building the machine controller**
+
+    ```
+    $ make -C cmd/machine-controller
+    ```
+
+4. **Deploying the cluster-api stack manifests**
+
+    Add your aws credentials to the `addons.yaml` file in base64 format:
+
+    ``` sh
+    $ echo -n 'your_id' | base64
+    $ echo -n 'your_key' | base64
+    ```
+
+    Deploy the components:
+
+    ```sh
+    $ kubectl apply -f examples/addons.yaml
+    $ kubectl apply -f examples/cluster-api-server.yaml
+    $ kubectl apply -f examples/provider-components.yml
+    ```
+
+    Deploy the machines:
+
+    ```sh
+    $ kubectl apply -f examples/machine.yaml --validate=false
+    ```
+
+    or alternatively:
+
+    ```sh
+    $ kubectl apply -f examples/machine-set.yaml --validate=false
+    ```

--- a/examples/addons.yaml
+++ b/examples/addons.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-aws-creds
+  namespace: test
+type: Opaque
+data:
+  awsAccessKeyId: 
+  awsSecretAccessKey: 

--- a/examples/cluster-api-server.yaml
+++ b/examples/cluster-api-server.yaml
@@ -1,0 +1,220 @@
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+  name: v1alpha1.cluster.k8s.io
+  labels:
+    api: clusterapi
+    apiserver: "true"
+spec:
+  version: v1alpha1
+  group: cluster.k8s.io
+  groupPriorityMinimum: 2000
+  priority: 200
+  service:
+    name: clusterapi
+    namespace: default
+  versionPriority: 10
+  caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM5RENDQWR5Z0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFyTVNrd0p3WURWUVFERXlCamJIVnoKZEdWeVlYQnBMV05sY25ScFptbGpZWFJsTFdGMWRHaHZjbWwwZVRBZUZ3MHhPREE0TURreE5EUXhOVFZhRncweQpPREE0TURZeE5EUXhOVFZhTUNzeEtUQW5CZ05WQkFNVElHTnNkWE4wWlhKaGNHa3RZMlZ5ZEdsbWFXTmhkR1V0CllYVjBhRzl5YVhSNU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBTUlJQkNnS0NBUUVBNXU3QkdCODUKKzNPT0NIV0NCQjYrWFNSTkNxelhTazBCUFo5YjBsbkdBZGVLNHdxc2h2SUhhZ0N2WHRGZEx3Q21zMVBXbzNHMApUM2ExY2h6TVBSUFNwV01tcldDei9Ibm1zOG45RkVjZi9BRGJXcmw4V2I5akJlbHNlWGlQS2dyYVY4dnp6N0xHCnJvdDZMV2Q0RjVUaUo4Q2FuaGl3dTFqT1RkK2FiNHRxc0ZDU05CZDRzTXc0Y2loejNjVzZoNnZmTlJtZ2VDaUcKNXp4S2RRTlBNT08rZ01rQjZJUXZPcG5MdllEMWxDTkRMTHY0c3NKNncxbUxlVHZGME9BT3A5NWxuT3k0MUtJSgpWK1RaVGlMZHZ5aFdRMmJEekwvbG9vNitHSUJ5NWJMeGdBV3FUcGQ3blU5NElzWEpuQ1NQR20zUzVOLy96TjJSCnlzTTU1cnlSNlVMWlpRSURBUUFCb3lNd0lUQU9CZ05WSFE4QkFmOEVCQU1DQXFRd0R3WURWUjBUQVFIL0JBVXcKQXdFQi96QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEyQnI3MGNMT1BXM1g3bHpKdXBlOFpBTUM4Uk4rMUtwTgoxLzF2NitSNU1xMEtnSlFzTnFnUC9ZQWRUdGFvcVRsaGVhMnFMenBPSDBmNHlNZWthckhPd2VxZjVLL1JwLzdoCk1vNG9jT1ZUZm13OStWZmZ4Nk9RVHhxTTZ1dkszSXd6ZlBJa25hMWFsS3pBTmlxVkM5UTg0NExzMG42RDJDazUKK245Um82TUd5d1gybkVvUDd2bFJHdnB3ejExV0ZjcWNPTWp3WTV1aUlpdUlSOGhTNmpOSmJ6OUgvME5nNTB3egpOSFJOc3ltWkdvTEtYMDBBbjJyVVZ5ME53TllyNDAwR0VRQnVwcEtsNHJaNmw1UFR4N2ZoNy8zd0FOM0pmWEUwClA2NlFvY081WnJYQXF3ZXpva215bWp4MzFraElnRnZObDhUYzFXaEVmN01PbWRTd1duUUNQdz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clusterapi
+  namespace: default
+  labels:
+    api: clusterapi
+    apiserver: "true"
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 443
+  selector:
+    api: clusterapi
+    apiserver: "true"
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: clusterapi-apiserver
+  namespace: default
+  labels:
+    api: clusterapi
+    apiserver: "true"
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        api: clusterapi
+        apiserver: "true"
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoExecute
+        key: node.alpha.kubernetes.io/notReady
+        operator: Exists
+      - effect: NoExecute
+        key: node.alpha.kubernetes.io/unreachable
+        operator: Exists
+      containers:
+      - name: apiserver
+        image: gcr.io/k8s-cluster-api/cluster-apiserver:0.0.6
+        volumeMounts:
+        - name: cluster-apiserver-certs
+          mountPath: /apiserver.local.config/certificates
+          readOnly: true
+        - name: config
+          mountPath: /etc/kubernetes
+        - name: certs
+          mountPath: /etc/ssl/certs
+        command:
+        - "./apiserver"
+        args:
+        - "--etcd-servers=http://etcd-clusterapi-svc:2379"
+        - "--tls-cert-file=/apiserver.local.config/certificates/tls.crt"
+        - "--tls-private-key-file=/apiserver.local.config/certificates/tls.key"
+        - "--audit-log-path=-"
+        - "--audit-log-maxage=0"
+        - "--audit-log-maxbackup=0"
+        - "--authorization-kubeconfig=/etc/kubernetes/admin.conf"
+        - "--kubeconfig=/etc/kubernetes/admin.conf"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 50Mi
+          limits:
+            cpu: 300m
+            memory: 200Mi
+      volumes:
+      - name: cluster-apiserver-certs
+        secret:
+          secretName: cluster-apiserver-certs
+      - name: config
+        hostPath:
+          path: /etc/kubernetes
+      - name: certs
+        hostPath:
+          path: /etc/ssl/certs
+---
+apiVersion: rbac.authorization.k8s.io/
+kind: RoleBinding
+metadata:
+  name: clusterapi
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: default
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: etcd-clusterapi
+  namespace: default
+spec:
+  serviceName: "etcd"
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: etcd
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoExecute
+        key: node.alpha.kubernetes.io/notReady
+        operator: Exists
+      - effect: NoExecute
+        key: node.alpha.kubernetes.io/unreachable
+        operator: Exists
+      volumes:
+      - hostPath:
+          path: /var/lib/etcd2
+          type: DirectoryOrCreate
+        name: etcd-data-dir
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: etcd
+        image: k8s.gcr.io/etcd:3.1.12
+        resources:
+          requests:
+            cpu: 100m
+            memory: 50Mi
+          limits:
+            cpu: 200m
+            memory: 300Mi
+        env:
+        - name: ETCD_DATA_DIR
+          value: /etcd-data-dir
+        command:
+        - /usr/local/bin/etcd
+        - --listen-client-urls
+        - http://0.0.0.0:2379
+        - --advertise-client-urls
+        - http://localhost:2379
+        ports:
+        - containerPort: 2379
+        volumeMounts:
+        - name: etcd-data-dir
+          mountPath: /etcd-data-dir
+        readinessProbe:
+          httpGet:
+            port: 2379
+            path: /health
+          failureThreshold: 1
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 2
+        livenessProbe:
+          httpGet:
+            port: 2379
+            path: /health
+          failureThreshold: 3
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: etcd-clusterapi-svc
+  namespace: default
+  labels:
+    app: etcd
+spec:
+  ports:
+  - port: 2379
+    name: etcd
+    targetPort: 2379
+  selector:
+    app: etcd
+---
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  name: cluster-apiserver-certs
+  namespace: default
+  labels:
+    api: clusterapi
+    apiserver: "true"
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lJT3RCZ0hiT3pnZWN3RFFZSktvWklodmNOQVFFTEJRQXdLekVwTUNjR0ExVUUKQXhNZ1kyeDFjM1JsY21Gd2FTMWpaWEowYVdacFkyRjBaUzFoZFhSb2IzSnBkSGt3SGhjTk1UZ3dPREE1TVRRMApNVFUxV2hjTk1Ua3dPREE1TVRRME1UVTFXakFoTVI4d0hRWURWUVFERXhaamJIVnpkR1Z5WVhCcExtUmxabUYxCmJIUXVjM1pqTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUEwQzdBVk9qQ2NuTHAKRngrSll6Q3JjYUJHZHpFMzRUeWxWTTFYUWhhK2R1ODJmVHY3cUQwWS93VGFOdjBlWm1hSDJJY3VKOXluR3dJUgpabTNWNDI4dWxzK01pQU45ZDhqVVdvcTNCL0RpVVoxZERQQ1JZd3ZxVFQwMk83MEdGNkZlMGpGTXFKVTVJOWYyCk9NOTlpeVA5dGlYWUM0MjNrQlBMN203ZDlUTFhIS2todkZkRmxVS1paSTJrSTQ3L29JYmttNlVWd25GT0pvNDcKenNhOFQranc2UUhQbUF2cGlnWDFQcEJManlqa1hiZ1dkcmdJNXJlamlTVnM5TEl1MGtsRkQvQ3NMUjBvL0YyeAo5cWtvZmM4ZjFIUlh4TE5scTlKdUxCMEJnWWd4cElqQm9aNW9McmJneGsyenVWT3NILzZLbXMzSFc5UGxXb3hoClBpVm9CYTVFSlFJREFRQUJvNEdSTUlHT01BNEdBMVVkRHdFQi93UUVBd0lGb0RBVEJnTlZIU1VFRERBS0JnZ3IKQmdFRkJRY0RBVEJuQmdOVkhSRUVZREJlZ2dwamJIVnpkR1Z5WVhCcGdoSmpiSFZ6ZEdWeVlYQnBMbVJsWm1GMQpiSFNDRm1Oc2RYTjBaWEpoY0drdVpHVm1ZWFZzZEM1emRtT0NKR05zZFhOMFpYSmhjR2t1WkdWbVlYVnNkQzV6CmRtTXVZMngxYzNSbGNpNXNiMk5oYkRBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQXJabE5INlQwQ1dyVXI4Vm0KeHZCa2VqTlRiT0RzWXV1aGRxR2dzOS9LbW9xTFhTcmRqV2ErKzdOY2lxR3NLb0RaTUlydTJ3ekQ4NG5SSERLUgo1Z3lCeVJIRjVXNTgzRVhRTmp3Z1h4SnBXbm1sb3ZSaWtwcm96OTllOVhCREczeDNtUzliK0pqVWJNeE92OW9JCndXZm15SDN3SHNhczN6WkNDU2lzNDluM3hzQVJrUlk2RXN3em1HS0xubzlVWUlkbkcyRHpPZTJKdjROOEhlTjcKT0xVOXRMQWlXRkRhYnNuV3F2YnlPekwzR2RqYVdmVURqbUZoWDhFSzgrNVBNZVJFd3UrR1ppTzFvMVFFVjY4OAo1a3pNUCs4ZndRVlRWMDN2Smk3UW5odWNwT2hXMFZaZm9pT0t0MGt0aFBnKzJSMDFwOGh3RzBxZHgrVTVrSHpUClQzZ09rQT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+  tls.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcEFJQkFBS0NBUUVBMEM3QVZPakNjbkxwRngrSll6Q3JjYUJHZHpFMzRUeWxWTTFYUWhhK2R1ODJmVHY3CnFEMFkvd1RhTnYwZVptYUgySWN1Sjl5bkd3SVJabTNWNDI4dWxzK01pQU45ZDhqVVdvcTNCL0RpVVoxZERQQ1IKWXd2cVRUMDJPNzBHRjZGZTBqRk1xSlU1STlmMk9NOTlpeVA5dGlYWUM0MjNrQlBMN203ZDlUTFhIS2todkZkRgpsVUtaWkkya0k0Ny9vSWJrbTZVVnduRk9KbzQ3enNhOFQranc2UUhQbUF2cGlnWDFQcEJManlqa1hiZ1dkcmdJCjVyZWppU1ZzOUxJdTBrbEZEL0NzTFIwby9GMng5cWtvZmM4ZjFIUlh4TE5scTlKdUxCMEJnWWd4cElqQm9aNW8KTHJiZ3hrMnp1Vk9zSC82S21zM0hXOVBsV294aFBpVm9CYTVFSlFJREFRQUJBb0lCQVFDdzRraEEzTlA2Y25CaQpXVVZlcGdmRnI2eXZzWDROUG40cm81MDBaaWJHMzFHbzdzSlFuRGtVMVlham1rV3VOQWZRam10RksxSkF2RzBVClh0YVJPL0tWNlJzNnBkeUJYbjR2d0JUc0Jsd0ZoSE4vZnhmSTFHTHI1Y3FpejJUUnh5Yk42VjE5RCsxUTZ6b2wKNHdhRXBydjNmQWdwS095QzJvODNzN09ibHVyM1NhUmxhWFYzM1VZVTY3SWhZN1lQTlVxdm1waHB5UUpVVGJFSwo5RHNMUFFzQUt3cUVGT0dOcTVmRENmTjRlUmM2VTVBVjVKa0txNTYxT2RrQy90YnlwL25YMG5idXJrdVB0STlmCkYrbzNzS1picVkyUFBSZ0NtaFhybFNrMW1TYkZDdnU5VS9sTHlUeTZQY1N4a2Y4M2ZNUGRQMVZ3Snd3V3pqQmEKMDhEQVY5T0JBb0dCQU5odUVMUHVoWTl0YkNKQVZqWkgwR3dWOTR5SWFkdE1Cbk54ZENZZGc0WitibzRVc0ZPMwpDM0x3ZURiSjZ2QVdyYktJMHRnenZuTnBMNFk4RTFRSTJKNlR2UTEyejhhdUNaQVI4T0pjQStUMUVJU1VncTZqCkZVL1ZFTElSYTZnbThDWDVXRmJJamdmVHpwYU1uNTVXWk1IU3cvVHlQdUlaRVArVU9SelZDb1o5QW9HQkFQWSsKckQvaXRsckc3SU5qK2Ywc1RoN0NUVmN2NklrUDVZYXNvVzUvRkhSemp1d0s5dTZkZnlWUTA0TjdmMktuWTM2awplemR1Mnc5Ry83WUE2UWRrbENQR0RXbVByY0REZUJhTWVOTC9UT2MzcU8xUTZVL2prRi9mV3V2MDMyaWpEQ1ZECnJ6NW1NLzAydGNXOFZNcnZWZ1drTHJ4VU9zcjFBZzB5T2JKdG1SekpBb0dBV2ltUUg4VlFNcTRkREMvTk9wTzAKU2pMa2k5RVFlR0UxbHNZKzR0b012dXpRMWJQY3VTTmFTNm5PQ3RVWFlLbXg5dHgxS2NoMG9OUEREcUxjVW5mVQo5a3NKeVNBajh0cng5T2prZHdocVB1bXcxZXFnZm14R0pwbldlTGcxSnpvQmRYQm8wczUrRE5pNkNaSFB0VUM4CmZOcDI5QVl2R0RYbEZQUUV6dlFaakdrQ2dZQlJodHA4cEZEL3FSQ3hSNjZDMWVKZmFMRTJocFFVblFDL0gvU3EKb3NSZzhjbUYrUE5jZVNTWmRETXpPdlluOFllTmJHT25MTHEyU2lsclZzM1FOc3FkTlh0SFVkeVRENlI0d3JWVwpGbFNkME4zTEJKamFiRnRtZ29xVnlKTVhEN1I3dWZjUlQ4RXl1cVJmL1VTTms4UUZSaUI3RmVBSlJpa1J1V2xFCjIraHZrUUtCZ1FDRTNCNHZaS3JiVXdYdXlYbnVBaXVWRlFCU3JqVkpscHFZMzgrVnVjQjBVQ3pVZzRCZWdZQ3EKdUxWelB1S1FSVVRWSzY2UEI5S1lGc1NxR2VVc0VHcEQwcEJrM09vcU42Q2RpbzA1MTdJYmVTcDV0dy9KYUduUgpPUmoyT1RSZmpab1BzcXJPbFVZOEEzVFZMWmM0MDhFQ3YxNVBlZGZXKzJUWS8ydTM2WGtCRkE9PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=

--- a/examples/machine-set.yaml
+++ b/examples/machine-set.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: Cluster
+metadata:
+  name: tb-asg-35
+  namespace: test
+spec:
+  clusterNetwork:
+    services:
+      cidrBlocks:
+        - "10.0.0.1/24"
+    pods:
+      cidrBlocks:
+        - "10.0.0.2/24"
+    serviceDomain: example.com
+---
+apiVersion: cluster.k8s.io/v1alpha1
+kind: MachineSet
+metadata:
+  name: aws-actuator-testing-machine
+  namespace: test
+  labels:
+    sigs.k8s.io/cluster-api-cluster: tb-asg-35
+    sigs.k8s.io/cluster-api-machine-role: infra
+    sigs.k8s.io/cluster-api-machine-type: master
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      sigs.k8s.io/cluster-api-machineset: test-master
+      sigs.k8s.io/cluster-api-cluster: tb-asg-35
+  template:
+    metadata:
+      labels:
+        sigs.k8s.io/cluster-api-machineset: test-master
+        sigs.k8s.io/cluster-api-cluster: tb-asg-35
+        sigs.k8s.io/cluster-api-machine-role: infra
+        sigs.k8s.io/cluster-api-machine-type: master
+    spec:
+      providerConfig:
+        value:
+          apiVersion: awsproviderconfig/v1alpha1
+          kind: AWSMachineProviderConfig
+          ami:
+            id: ami-a9acbbd6
+          credentialsSecret:
+            name: aws-credentials-secret
+          instanceType: m4.xlarge
+          placement:
+            region: us-east-1
+            availabilityZone: us-east-1a
+          subnet:
+            id: subnet-0e56b13a64ff8a941
+          iamInstanceProfile:
+            id: openshift_master_launch_instances
+          keyName: libra
+          tags:
+            - name: openshift-node-group-config
+              value: node-config-master
+            - name: host-type
+              value: master
+            - name: sub-host-type
+              value: default
+          securityGroups:
+            - id: sg-00868b02fbe29de17
+            - id: sg-0a4658991dc5eb40a
+            - id: sg-009a70e28fa4ba84e
+            - id: sg-07323d56fb932c84c
+            - id: sg-08b1ffd32874d59a2
+          publicIP: true

--- a/examples/machine.yaml
+++ b/examples/machine.yaml
@@ -1,9 +1,24 @@
 ---
 apiVersion: "cluster.k8s.io/v1alpha1"
+kind: Cluster
+metadata:
+  name: tb-asg-35
+  namespace: test
+spec:
+  clusterNetwork:
+    services:
+      cidrBlocks:
+        - "10.0.0.1/24"
+    pods:
+      cidrBlocks:
+        - "10.0.0.2/24"
+    serviceDomain: example.com
+---
+apiVersion: "cluster.k8s.io/v1alpha1"
 kind: Machine
 metadata:
   name: aws-actuator-testing-machine
-  namespace: default
+  namespace: test
   generateName: vs-master-
   labels:
     sigs.k8s.io/cluster-api-cluster: tb-asg-35
@@ -27,8 +42,6 @@ spec:
       iamInstanceProfile:
         id: openshift_master_launch_instances
       keyName: libra
-      userDataSecret:
-        name: aws-actuator-user-data-secret
       tags:
         - name: openshift-node-group-config
           value: node-config-master

--- a/examples/provider-components.yml
+++ b/examples/provider-components.yml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: clusterapi-controllers
+  labels:
+    api: clusterapi
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        api: clusterapi
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoExecute
+        key: node.alpha.kubernetes.io/notReady
+        operator: Exists
+      - effect: NoExecute
+        key: node.alpha.kubernetes.io/unreachable
+        operator: Exists
+      containers:
+      - name: controller-manager
+        image: gcr.io/k8s-cluster-api/controller-manager:0.0.7
+        volumeMounts:
+          - name: config
+            mountPath: /etc/kubernetes
+          - name: certs
+            mountPath: /etc/ssl/certs
+        command:
+        - "./controller-manager"
+        args:
+        - --kubeconfig=/etc/kubernetes/admin.conf
+        resources:
+          requests:
+            cpu: 100m
+            memory: 20Mi
+          limits:
+            cpu: 100m
+            memory: 30Mi
+      - name: aws-machine-controller
+        image: gcr.io/k8s-cluster-api/aws-machine-controller:0.0.1
+        volumeMounts:
+          - name: config
+            mountPath: /etc/kubernetes
+          - name: certs
+            mountPath: /etc/ssl/certs
+          - name: kubeadm
+            mountPath: /usr/bin/kubeadm
+        env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+        command:
+          - /machine-controller
+        args:
+          - --log-level=debug
+          - --kubeconfig=/etc/kubernetes/admin.conf
+        resources:
+          requests:
+            cpu: 100m
+            memory: 20Mi
+          limits:
+            cpu: 100m
+            memory: 30Mi
+      volumes:
+      - name: config
+        hostPath:
+          path: /etc/kubernetes
+      - name: certs
+        hostPath:
+          path: /etc/ssl/certs
+      - name: kubeadm
+        hostPath:
+          path: /usr/bin/kubeadm


### PR DESCRIPTION
The examples are still specific for resources assigned to `tb-asg-35` vpc. Yet, anyone with the proper aws credentials can reuse them.