### PR TITLE
Fix machine status updates due to wrong APIVersion.

### DIFF
--- a/cloud/aws/actuators/machine/utils.go
+++ b/cloud/aws/actuators/machine/utils.go
@@ -224,7 +224,7 @@ func AWSMachineProviderStatusFromMachineStatus(s *clusterv1.MachineStatus) (*pro
 // EncodeAWSMachineProviderStatus encodes the machine status into RawExtension
 func EncodeAWSMachineProviderStatus(awsStatus *providerconfigv1.AWSMachineProviderStatus) (*runtime.RawExtension, error) {
 	awsStatus.TypeMeta = metav1.TypeMeta{
-		APIVersion: clusterv1.SchemeGroupVersion.String(),
+		APIVersion: providerconfigv1.SchemeGroupVersion.String(),
 		Kind:       "AWSMachineProviderStatus",
 	}
 	serializer := jsonserializer.NewSerializer(jsonserializer.DefaultMetaFactory, providerconfigv1.Scheme, providerconfigv1.Scheme, false)


### PR DESCRIPTION
Provider status was being written the first time with APIVersion of
cluster.k8s.io which is not correct for the AWSMachineProviderStatus.
This would then fail to decode on all subsequent attempts to update
status.

This patch fixes but the apiVersion is now awsproviderconfig/v1alpha1,
which should also probably be fixed in a follow-up. https://github.com/openshift/cluster-api-provider-aws/issues/18

Worth noting the error appeared to get swallowed and never logged,
which also should be fixed in a follow-up. https://github.com/openshift/cluster-api-provider-aws/issues/17