### PR TITLE
examples/cluster-api-server: add missing version in RoleBinding

### DIFF
--- a/examples/cluster-api-server.yaml
+++ b/examples/cluster-api-server.yaml
@@ -102,7 +102,7 @@ spec:
         hostPath:
           path: /etc/ssl/certs
 ---
-apiVersion: rbac.authorization.k8s.io/
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: clusterapi


### PR DESCRIPTION
Fixes:

```console
Error from server (NotFound): error when
creating "examples/cluster-api-server.yaml":
the server could not find the requested resource.```