### PR TITLE
Add convenience script to update AWS secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,17 +71,27 @@ Note: this info is RH only, it needs to be backported every time the `README.md`
 
 4. **Deploying the cluster-api stack manifests**
 
-    Add your aws credentials to the `addons.yaml` file in base64 format:
+    Add your AWS credentials to the `addons.yaml` file (in base64
+    format). You can either do this manually or use the
+    `examples/render-aws-secrets.sh`.
+
+    The easy deployment is:
+
+    ```sh
+    ./examples/render-aws-secrets.sh examples/addons.yaml | kubectl apply -f -
+    ```
+
+    The manual deployment is:
 
     ``` sh
     $ echo -n 'your_id' | base64
     $ echo -n 'your_key' | base64
+    $ kubectl apply -f examples/addons.yaml
     ```
 
     Deploy the components:
 
     ```sh
-    $ kubectl apply -f examples/addons.yaml
     $ kubectl apply -f examples/cluster-api-server.yaml
     $ kubectl apply -f examples/provider-components.yml
     ```

--- a/examples/render-aws-secrets.sh
+++ b/examples/render-aws-secrets.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+if [ $# -lt 1 ]; then
+    echo "usage: $0 <filename>"
+    exit 1
+fi
+
+if [ -z "$AWS_ACCESS_KEY_ID" ]; then
+    echo "error: AWS_ACCESS_KEY_ID is not set in the environment" 2>&1
+    exit 1
+fi
+
+if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+    echo "error: AWS_SECRET_ACCESS_KEY is not set in the environment" 2>&1
+    exit 1
+fi
+
+x=$(echo -n "$AWS_ACCESS_KEY_ID" | base64)
+y=$(echo -n "$AWS_SECRET_ACCESS_KEY" | base64)
+
+sed -e "s/awsAccessKeyId:.*/awsAccessKeyId: $x/" \
+    -e "s/awsSecretAccessKey:.*/awsSecretAccessKey: $y/" \
+    "$1"


### PR DESCRIPTION
Convenience script to render AWS secrets:

    $ cd $GOPATH/sigs.k8s.io/cluster-api-provider-aws
    $ ./examples/update-aws-secrets.sh examples/addons.yaml
```yaml
apiVersion: v1
kind: Namespace
metadata:
  name: test
---
apiVersion: v1
kind: Secret
metadata:
  name: aws-credentials-secret
  namespace: test
type: Opaque
data:
  awsAccessKeyId: <REDACTED>
  awsSecretAccessKey: <REDACTED>
```

Normal usage would be:

    $ ./examples/render-aws-secrets.sh examples/addons.yaml | kubectl apply -f -

Only works if both:

- AWS_SECRET_ACCESS_KEY
- AWS_ACCESS_KEY_ID

are set in the environment.