### PR TITLE
New 'aws-actuator bootstrap` command to bootstrap the kubernetes cluster from scratch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ build:
 	CGO_ENABLED=0 go install -a -ldflags '-extldflags "-static"' sigs.k8s.io/cluster-api-provider-aws/cmd/cluster-controller
 	CGO_ENABLED=0 go install -a -ldflags '-extldflags "-static"' sigs.k8s.io/cluster-api-provider-aws/cmd/machine-controller
 
+aws-actuator:
+	go build -a -o bin/aws-actuator sigs.k8s.io/cluster-api-provider-aws/cmd/aws-actuator
+
 images:
 	$(MAKE) -C cmd/cluster-controller image
 	$(MAKE) -C cmd/machine-controller image

--- a/examples/worker-machine.yaml
+++ b/examples/worker-machine.yaml
@@ -13,7 +13,7 @@ spec:
       apiVersion: awsproviderconfig/v1alpha1
       kind: AWSMachineProviderConfig
       ami:
-        id: ami-0112c184e219ce91b
+        id: ami-060f14ef82deddfc6
       instanceType: m4.xlarge
       placement:
         region: us-east-1


### PR DESCRIPTION
Just run `./bin/aws-actuator bootstrap --manifests examples/` and get:

```
$ sudo kubectl get nodes
NAME                            STATUS    ROLES     AGE       VERSION
ip-172-31-33-59.ec2.internal    Ready     master    1m        v1.11.2
ip-172-31-35-115.ec2.internal   Ready     <none>    52s       v1.11.2
```