### PR TITLE
Prep Dockerfile for building with ART tooling.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,17 @@
 
 # Reproducible builder image
 FROM openshift/origin-release:golang-1.10 as builder
+
+# Workaround a bug in imagebuilder (some versions) where this dir will not be auto-created.
+RUN mkdir -p /go/src/sigs.k8s.io/cluster-api-provider-aws
 WORKDIR /go/src/sigs.k8s.io/cluster-api-provider-aws
+
 # This expects that the context passed to the docker build command is
 # the cluster-api-provider-aws directory.
 # e.g. docker build -t <tag> -f <this_Dockerfile> <path_to_cluster-api-aws>
-COPY . . 
+COPY . .
 
-RUN CGO_ENABLED=0 GOOS=linux go install -a -ldflags '-extldflags "-static"' sigs.k8s.io/cluster-api-provider-aws/cmd/machine-controller
+RUN GOPATH="/go" CGO_ENABLED=0 GOOS=linux go install -a -ldflags '-extldflags "-static"' sigs.k8s.io/cluster-api-provider-aws/cmd/machine-controller
 
 # Final container
 FROM openshift/origin-base

--- a/cmd/machine-controller/Makefile
+++ b/cmd/machine-controller/Makefile
@@ -21,7 +21,7 @@ NAME = aws-machine-controller
 TAG = 0.0.1
 
 image:
-	imagebuilder -t "$(PREFIX)/$(NAME):$(TAG)" -f ./Dockerfile ../..
+	imagebuilder -t "$(PREFIX)/$(NAME):$(TAG)" -f ../../Dockerfile ../..
 
 push: image
 	docker push "$(PREFIX)/$(NAME):$(TAG)"
@@ -32,7 +32,7 @@ fix_gcs_permissions:
 	gsutil -m acl ch -r -u AllUsers:READ gs://artifacts.$(GCR_BUCKET).appspot.com
 
 dev_image:
-	docker build -t "$(DEV_PREFIX)/$(NAME):$(TAG)-dev" -f ./Dockerfile ../..
+	docker build -t "$(DEV_PREFIX)/$(NAME):$(TAG)-dev" -f ../../Dockerfile ../..
 
 dev_push: dev_image
 	docker push "$(DEV_PREFIX)/$(NAME):$(TAG)-dev"


### PR DESCRIPTION
Move Dockerfile to project root to accomodate tooling, needs to have
source in build context.

Make sure GOPATH is set, it may not be in some build images that get
auto-replaced in for the FROM.

Workaround a bug in some versions of imagebuilder where WORKDIR will not
create the directory if it doesn't exist.


We can't yet test this but I spoke with lmeyer and he spotted a couple things that might be needed, so submitting a PR for those. Let me know if anything else needs to be updated, I may have missed other routes to the Dockerfile I'm not aware of.

CC @enxebre @paulfantom 