### PR TITLE
Annotate workers with node role

### DIFF
--- a/examples/worker-machineset.yaml
+++ b/examples/worker-machineset.yaml
@@ -17,6 +17,8 @@ spec:
       labels:
         sigs.k8s.io/cluster-api-machineset: worker-machine
         sigs.k8s.io/cluster-api-cluster: tb-asg-35
+      annotations:
+        sigs.k8s.io/cluster-api-node-role: compute
     spec:
       providerConfig:
         value:


### PR DESCRIPTION
Once needs to run `nodelink-controller` controller to properly label the nodes:

```
./bin/nodelink-controller --kubeconfig=KUBECONFIG
```

The functionality will be available once https://github.com/openshift/machine-api-operator/pull/72 gets merged. Not blocker for this PR however.