### PR TITLE
E2E: verify node roles and node machine matching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ aws-actuator:
 
 .PHONY: images
 images: ## Create images
-	$(MAKE) -C cmd/cluster-controller image
+	#$(MAKE) -C cmd/cluster-controller image
 	$(MAKE) -C cmd/machine-controller image
 
 .PHONY: push
@@ -68,7 +68,7 @@ integration: ## Run integration test
 
 .PHONY: test-e2e
 test-e2e: ## Run e2e test
-	go test -v sigs.k8s.io/cluster-api-provider-aws/test/machines -kubeconfig $${KUBECONFIG:-~/.kube/config} -cluster-id $${ENVIRONMENT_ID:-""} -ginkgo.v
+	go test -timeout 20m -v sigs.k8s.io/cluster-api-provider-aws/test/machines -kubeconfig $${KUBECONFIG:-~/.kube/config} -ssh-key $${SSH_PK:-~/.ssh/id_rsa} -cluster-id $${ENVIRONMENT_ID:-""} -ginkgo.v
 
 .PHONY: lint
 lint: ## Go lint your code

--- a/examples/provider-components.yml
+++ b/examples/provider-components.yml
@@ -43,6 +43,24 @@ spec:
           limits:
             cpu: 100m
             memory: 30Mi
+      - name: nodelink-controller
+        image: openshift/origin-machine-api-operator:latest
+        volumeMounts:
+        - name: config
+          mountPath: /etc/kubernetes
+        - name: certs
+          mountPath: /etc/ssl/certs
+        command:
+        - "./nodelink-controller"
+        args:
+        - --kubeconfig=/etc/kubernetes/admin.conf
+        resources:
+          requests:
+            cpu: 100m
+            memory: 20Mi
+          limits:
+            cpu: 100m
+            memory: 30Mi
       - name: aws-machine-controller
         image: openshift/origin-aws-machine-controllers:v4.0.0
         volumeMounts:

--- a/test/framework/clusterapi.go
+++ b/test/framework/clusterapi.go
@@ -1,0 +1,179 @@
+package framework
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/common/log"
+
+	"sigs.k8s.io/cluster-api-provider-aws/test/utils"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (f *Framework) DeployClusterAPIStack(clusterAPINamespace string) {
+
+	By("Deploy cluster API stack components")
+	certsSecret, apiAPIService, err := utils.ClusterAPIServerAPIServiceObjects(clusterAPINamespace)
+	Expect(err).NotTo(HaveOccurred())
+	_, err = f.KubeClient.CoreV1().Secrets(certsSecret.Namespace).Create(certsSecret)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = wait.Poll(PollInterval, PoolTimeout, func() (bool, error) {
+		if _, err := f.KubeClient.CoreV1().Secrets(certsSecret.Namespace).Get(certsSecret.Name, metav1.GetOptions{}); err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	_, err = f.APIRegistrationClient.Apiregistration().APIServices().Create(apiAPIService)
+	Expect(err).NotTo(HaveOccurred())
+
+	apiService := utils.ClusterAPIService(clusterAPINamespace)
+	_, err = f.KubeClient.CoreV1().Services(apiService.Namespace).Create(apiService)
+	Expect(err).NotTo(HaveOccurred())
+
+	clusterAPIDeployment := utils.ClusterAPIDeployment(clusterAPINamespace)
+	_, err = f.KubeClient.AppsV1beta2().Deployments(clusterAPIDeployment.Namespace).Create(clusterAPIDeployment)
+	Expect(err).NotTo(HaveOccurred())
+
+	clusterAPIControllersDeployment := utils.ClusterAPIControllersDeployment(clusterAPINamespace)
+	_, err = f.KubeClient.AppsV1beta2().Deployments(clusterAPIDeployment.Namespace).Create(clusterAPIControllersDeployment)
+	Expect(err).NotTo(HaveOccurred())
+
+	clusterAPIRoleBinding := utils.ClusterAPIRoleBinding(clusterAPINamespace)
+	_, err = f.KubeClient.RbacV1().RoleBindings(clusterAPIRoleBinding.Namespace).Create(clusterAPIRoleBinding)
+	Expect(err).NotTo(HaveOccurred())
+
+	clusterAPIEtcdCluster := utils.ClusterAPIEtcdCluster(clusterAPINamespace)
+	_, err = f.KubeClient.AppsV1beta2().StatefulSets(clusterAPIEtcdCluster.Namespace).Create(clusterAPIEtcdCluster)
+	Expect(err).NotTo(HaveOccurred())
+
+	etcdService := utils.ClusterAPIEtcdService(clusterAPINamespace)
+	_, err = f.KubeClient.CoreV1().Services(etcdService.Namespace).Create(etcdService)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Waiting for cluster API stack to come up")
+	err = wait.Poll(PollInterval, PoolClusterAPIDeploymentTimeout, func() (bool, error) {
+		if deployment, err := f.KubeClient.AppsV1beta2().Deployments(clusterAPIDeployment.Namespace).Get(clusterAPIDeployment.Name, metav1.GetOptions{}); err == nil {
+			// Check all the pods are running
+			log.Infof("Waiting for all cluster-api deployment pods to be ready, have %v, expecting 1", deployment.Status.ReadyReplicas)
+			if deployment.Status.ReadyReplicas < 1 {
+				return false, nil
+			}
+			return true, nil
+		}
+
+		return false, nil
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Cluster API stack deployed")
+}
+
+func (f *Framework) DestroyClusterAPIStack(clusterAPINamespace string) {
+	var orphanDeletepolicy metav1.DeletionPropagation = "Orphan"
+	var zero int64 = 0
+
+	By("Deleting etcd service")
+	etcdService := utils.ClusterAPIEtcdService(clusterAPINamespace)
+	err := WaitUntilDeleted(func() error {
+		return f.KubeClient.CoreV1().Services(etcdService.Namespace).Delete(etcdService.Name, &metav1.DeleteOptions{})
+	}, func() error {
+		_, err := f.KubeClient.CoreV1().Services(etcdService.Namespace).Get(etcdService.Name, metav1.GetOptions{})
+		return err
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Scaling down etcd cluster")
+	clusterAPIEtcdCluster := utils.ClusterAPIEtcdCluster(clusterAPINamespace)
+	f.ScaleSatefulSetDownToZero(clusterAPIEtcdCluster)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Deleting etcd cluster")
+	WaitUntilDeleted(func() error {
+		return f.KubeClient.AppsV1beta2().StatefulSets(clusterAPIEtcdCluster.Namespace).Delete(clusterAPIEtcdCluster.Name, &metav1.DeleteOptions{PropagationPolicy: &orphanDeletepolicy, GracePeriodSeconds: &zero})
+	}, func() error {
+		obj, err := f.KubeClient.AppsV1beta2().StatefulSets(clusterAPIEtcdCluster.Namespace).Get(clusterAPIEtcdCluster.Name, metav1.GetOptions{})
+		fmt.Printf("obj: %#v\n", obj)
+		return err
+	})
+	// Ignore the error, the deployment has 0 replicas.
+	// No longer affecting future deployments since it lives in a different namespace.
+
+	By("Deleting role binding")
+	clusterAPIRoleBinding := utils.ClusterAPIRoleBinding(clusterAPINamespace)
+	err = WaitUntilDeleted(func() error {
+		return f.KubeClient.RbacV1().RoleBindings(clusterAPIRoleBinding.Namespace).Delete(clusterAPIRoleBinding.Name, &metav1.DeleteOptions{})
+	}, func() error {
+		_, err := f.KubeClient.RbacV1().RoleBindings(clusterAPIRoleBinding.Namespace).Get(clusterAPIRoleBinding.Name, metav1.GetOptions{})
+		return err
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	clusterAPIControllersDeployment := utils.ClusterAPIControllersDeployment(clusterAPINamespace)
+	By("Scaling down controllers deployment")
+	err = f.ScaleDeploymentDownToZero(clusterAPIControllersDeployment)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Deleting controllers deployment")
+	WaitUntilDeleted(func() error {
+		return f.KubeClient.AppsV1beta2().Deployments(clusterAPIControllersDeployment.Namespace).Delete(clusterAPIControllersDeployment.Name, &metav1.DeleteOptions{PropagationPolicy: &orphanDeletepolicy, GracePeriodSeconds: &zero})
+	}, func() error {
+		_, err := f.KubeClient.AppsV1beta2().Deployments(clusterAPIControllersDeployment.Namespace).Get(clusterAPIControllersDeployment.Name, metav1.GetOptions{})
+		return err
+	})
+	// Ignore the error, the deployment has 0 replicas.
+	// No longer affecting future deployments since it lives in a different namespace.
+
+	clusterAPIDeployment := utils.ClusterAPIDeployment(clusterAPINamespace)
+	By("Scaling down apiserver deployment")
+	err = f.ScaleDeploymentDownToZero(clusterAPIDeployment)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Deleting apiserver deployment")
+	WaitUntilDeleted(func() error {
+		return f.KubeClient.AppsV1beta2().Deployments(clusterAPIDeployment.Namespace).Delete(clusterAPIDeployment.Name, &metav1.DeleteOptions{PropagationPolicy: &orphanDeletepolicy, GracePeriodSeconds: &zero})
+	}, func() error {
+		_, err := f.KubeClient.AppsV1beta2().Deployments(clusterAPIDeployment.Namespace).Get(clusterAPIDeployment.Name, metav1.GetOptions{})
+		return err
+	})
+	// Ignore the error, the deployment has 0 replicas.
+	// No longer affecting future deployments since it lives in a different namespace.
+
+	By("Deleting cluster api service")
+	apiService := utils.ClusterAPIService(clusterAPINamespace)
+	err = WaitUntilDeleted(func() error {
+		return f.KubeClient.CoreV1().Services(apiService.Namespace).Delete(apiService.Name, &metav1.DeleteOptions{})
+	}, func() error {
+		_, err := f.KubeClient.CoreV1().Services(apiService.Namespace).Get(apiService.Name, metav1.GetOptions{})
+		return err
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	// Even though the certs are different, only the secret name(space) and apiservice name(space) are actually used
+	certsSecret, apiAPIService, err := utils.ClusterAPIServerAPIServiceObjects(clusterAPINamespace)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Deleting cluster api api service")
+	err = WaitUntilDeleted(func() error {
+		return f.APIRegistrationClient.Apiregistration().APIServices().Delete(apiAPIService.Name, &metav1.DeleteOptions{})
+	}, func() error {
+		_, err := f.APIRegistrationClient.Apiregistration().APIServices().Get(apiAPIService.Name, metav1.GetOptions{})
+		return err
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Deleting api server certs")
+	err = WaitUntilDeleted(func() error {
+		return f.KubeClient.CoreV1().Secrets(certsSecret.Namespace).Delete(certsSecret.Name, &metav1.DeleteOptions{})
+	}, func() error {
+		_, err := f.KubeClient.CoreV1().Secrets(certsSecret.Namespace).Get(certsSecret.Name, metav1.GetOptions{})
+		return err
+	})
+	Expect(err).NotTo(HaveOccurred())
+}

--- a/test/framework/clusters.go
+++ b/test/framework/clusters.go
@@ -1,0 +1,35 @@
+package framework
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clusterv1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/common/log"
+)
+
+func (f *Framework) CreateClusterAndWait(cluster *clusterv1alpha1.Cluster) {
+	By(fmt.Sprintf("Creating %q cluster", cluster.Name))
+	err := wait.Poll(PollInterval, PoolTimeout, func() (bool, error) {
+		_, err := f.CAPIClient.ClusterV1alpha1().Clusters(cluster.Namespace).Create(cluster)
+		if err != nil {
+			log.Infof("error creating cluster: %v", err)
+			return false, nil
+		}
+		return true, nil
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	err = wait.Poll(PollInterval, PoolTimeout, func() (bool, error) {
+		_, err := f.CAPIClient.ClusterV1alpha1().Clusters(cluster.Namespace).Get(cluster.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+	Expect(err).NotTo(HaveOccurred())
+}

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -2,10 +2,19 @@ package framework
 
 import (
 	"flag"
+	"fmt"
+	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/kubernetes-incubator/apiserver-builder/pkg/controller"
+	"github.com/prometheus/common/log"
+
+	appsv1beta2 "k8s.io/api/apps/v1beta2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	apiregistrationclientset "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 
@@ -13,14 +22,39 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+const (
+	// Default timeout for pools
+	PoolTimeout = 20 * time.Second
+	// Default waiting interval for pools
+	PollInterval = 1 * time.Second
+	// Node waiting internal
+	PollNodeInterval = 5 * time.Second
+	// Pool timeout for cluster API deployment
+	PoolClusterAPIDeploymentTimeout = 10 * time.Minute
+	PoolDeletionTimeout             = 1 * time.Minute
+	// Pool timeout for kubeconfig
+	PoolKubeConfigTimeout = 10 * time.Minute
+	PoolNodesReadyTimeout = 5 * time.Minute
+	// Instances are running timeout
+	TimeoutPoolMachineRunningInterval = 10 * time.Minute
+)
+
 var kubeconfig string
 
 // ClusterID set by -cluster-id flag
 var ClusterID string
 
+// Path to private ssh to connect to instances (e.g. to download kubeconfig or copy docker images)
+var sshkey string
+
+var actuatorImage string
+
 func init() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "kubeconfig file")
 	flag.StringVar(&ClusterID, "cluster-id", "", "cluster ID")
+	flag.StringVar(&sshkey, "ssh-key", "", "Path to private ssh to connect to instances (e.g. to download kubeconfig or copy docker images)")
+	flag.StringVar(&actuatorImage, "actuator-image", "gcr.io/k8s-cluster-api/aws-machine-controller:0.0.1", "Actuator image to run")
+
 	flag.Parse()
 }
 
@@ -30,57 +64,201 @@ type Framework struct {
 	CAPIClient            *clientset.Clientset
 	APIRegistrationClient *apiregistrationclientset.Clientset
 	Kubeconfig            string
+	RestConfig            *rest.Config
+	SSHKey                string
+	ActuatorImage         string
 }
 
 // NewFramework setups a new framework
 func NewFramework() *Framework {
+	if sshkey == "" {
+		panic("-sskey not set")
+	}
+	if kubeconfig == "" {
+		panic("-kubeconfig not set")
+	}
 	f := &Framework{
-		Kubeconfig: kubeconfig,
+		Kubeconfig:    kubeconfig,
+		SSHKey:        sshkey,
+		ActuatorImage: actuatorImage,
 	}
 
 	BeforeEach(f.BeforeEach)
-
 	return f
 }
 
-// BeforeEach to be run before each spec responsible for building various clientsets
-func (f *Framework) BeforeEach() {
+func NewFrameworkFromConfig(config *rest.Config) *Framework {
+	if sshkey == "" {
+		panic("-sskey not set")
+	}
+
+	f := &Framework{
+		RestConfig:    config,
+		SSHKey:        sshkey,
+		ActuatorImage: actuatorImage,
+	}
+
+	f.buildClientsets()
+	return f
+}
+
+func (f *Framework) buildClientsets() {
+	var err error
+
 	By("Creating a kubernetes client")
+	if f.RestConfig == nil {
+		f.RestConfig, err = controller.GetConfig(f.Kubeconfig)
+		Expect(err).NotTo(HaveOccurred())
+	}
 
 	if f.KubeClient == nil {
-		config, err := controller.GetConfig(f.Kubeconfig)
-		Expect(err).NotTo(HaveOccurred())
-		f.KubeClient, err = kubernetes.NewForConfig(config)
+		f.KubeClient, err = kubernetes.NewForConfig(f.RestConfig)
 		Expect(err).NotTo(HaveOccurred())
 	}
 
 	if f.CAPIClient == nil {
-		config, err := controller.GetConfig(f.Kubeconfig)
-		Expect(err).NotTo(HaveOccurred())
-		f.CAPIClient, err = clientset.NewForConfig(config)
+		f.CAPIClient, err = clientset.NewForConfig(f.RestConfig)
 		Expect(err).NotTo(HaveOccurred())
 	}
 
 	if f.APIRegistrationClient == nil {
-		config, err := controller.GetConfig(f.Kubeconfig)
-		Expect(err).NotTo(HaveOccurred())
-		f.APIRegistrationClient, err = apiregistrationclientset.NewForConfig(config)
+		f.APIRegistrationClient, err = apiregistrationclientset.NewForConfig(f.RestConfig)
 		Expect(err).NotTo(HaveOccurred())
 	}
+}
 
+// BeforeEach to be run before each spec responsible for building various clientsets
+func (f *Framework) BeforeEach() {
+	f.buildClientsets()
+}
+
+func (f *Framework) ScaleSatefulSetDownToZero(statefulset *appsv1beta2.StatefulSet) error {
+	var zero int32 = 0
+	statefulset.Spec.Replicas = &zero
+	err := wait.Poll(PollInterval, PoolDeletionTimeout, func() (bool, error) {
+		// give it some time
+		_, err := f.KubeClient.AppsV1beta2().StatefulSets(statefulset.Namespace).Update(statefulset)
+		log.Infof("ScaleSatefulSetDownToZero.err: %v\n", err)
+		if err != nil {
+			if strings.Contains(err.Error(), "not found") {
+				return true, nil
+			}
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// Now wait the number of replicas is really zero
+	return wait.Poll(PollInterval, PoolDeletionTimeout, func() (bool, error) {
+		// give it some time
+		result, err := f.KubeClient.AppsV1beta2().StatefulSets(statefulset.Namespace).Get(statefulset.Name, metav1.GetOptions{})
+		if err != nil {
+			if strings.Contains(err.Error(), "not found") {
+				return true, nil
+			}
+			return false, nil
+		}
+		fmt.Printf("result: %v\n", result.Status.CurrentReplicas)
+		if result.Status.CurrentReplicas == 0 {
+			return true, nil
+		}
+		return false, nil
+	})
+}
+
+func (f *Framework) ScaleDeploymentDownToZero(deployment *appsv1beta2.Deployment) error {
+	var zero int32 = 0
+	deployment.Spec.Replicas = &zero
+	err := wait.Poll(PollInterval, PoolDeletionTimeout, func() (bool, error) {
+		// give it some time
+		_, err := f.KubeClient.AppsV1beta2().Deployments(deployment.Namespace).Update(deployment)
+		log.Infof("ScaleDeploymentDownToZero.err: %v\n", err)
+		if err != nil {
+			if strings.Contains(err.Error(), "not found") {
+				return true, nil
+			}
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// Now wait the number of replicas is really zero
+	return wait.Poll(PollInterval, PoolDeletionTimeout, func() (bool, error) {
+		// give it some time
+		result, err := f.KubeClient.AppsV1beta2().Deployments(deployment.Namespace).Get(deployment.Name, metav1.GetOptions{})
+		if err != nil {
+			if strings.Contains(err.Error(), "not found") {
+				return true, nil
+			}
+			return false, nil
+		}
+		fmt.Printf("result: %v\n", result.Status.AvailableReplicas)
+		if result.Status.AvailableReplicas == 0 {
+			return true, nil
+		}
+		return false, nil
+	})
+}
+
+func WaitUntilDeleted(delFnc func() error, getFnc func() error) error {
+	return wait.Poll(PollInterval, PoolDeletionTimeout, func() (bool, error) {
+
+		err := delFnc()
+		log.Infof("del.err: %v\n", err)
+		if err != nil {
+			if strings.Contains(err.Error(), "object is being deleted") {
+				return false, nil
+			}
+			if strings.Contains(err.Error(), "not found") {
+				return true, nil
+			}
+			return false, nil
+		}
+
+		err = getFnc()
+		log.Infof("get.err: %v\n", err)
+		if err != nil && strings.Contains(err.Error(), "not found") {
+			return true, nil
+		}
+		return false, nil
+	})
 }
 
 // IgnoreNotFoundErr ignores not found errors in case resource
 // that does not exist is to be deleted
 func IgnoreNotFoundErr(err error) {
 	if err != nil {
-		if !strings.Contains(err.Error(), "not found") {
-			Expect(err).NotTo(HaveOccurred())
+		if strings.Contains(err.Error(), "not found") {
+			return
 		}
+		Expect(err).NotTo(HaveOccurred())
 	}
 }
 
 // SigKubeDescribe is a wrapper function for ginkgo describe.  Adds namespacing.
 func SigKubeDescribe(text string, body func()) bool {
 	return Describe("[sigs.k8s.io] "+text, body)
+}
+
+func (f *Framework) UploadDockerImageToInstance(image, targetMachine string) error {
+	log.Infof("Uploading %q to the master machine under %q", image, targetMachine)
+	cmd := exec.Command("bash", "-c", fmt.Sprintf(
+		"docker save %v | bzip2 | ssh -o StrictHostKeyChecking=no -i %v ec2-user@%v \"bunzip2 > /tmp/tempimage.bz2 && sudo docker load -i /tmp/tempimage.bz2\"",
+		image,
+		f.SSHKey,
+		targetMachine,
+	))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Info(string(out))
+		return err
+	}
+	log.Info(string(out))
+	return nil
 }

--- a/test/framework/machines.go
+++ b/test/framework/machines.go
@@ -1,0 +1,385 @@
+package framework
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"strings"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/prometheus/common/log"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clusterv1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type CloudProviderClient interface {
+	// Get running instances (of a given cloud provider) managed by the machine object
+	GetRunningInstances(machine *clusterv1alpha1.Machine) ([]interface{}, error)
+	// Get running instance public DNS name
+	GetPublicDNSName(machine *clusterv1alpha1.Machine) (string, error)
+	// Get private IP
+	GetPrivateIP(machine *clusterv1alpha1.Machine) (string, error)
+}
+
+func (f *Framework) DeleteMachineAndWait(machine *clusterv1alpha1.Machine, client CloudProviderClient) {
+	By(fmt.Sprintf("Deleting %q machine", machine.Name))
+	err := f.CAPIClient.ClusterV1alpha1().Machines(machine.Namespace).Delete(machine.Name, &metav1.DeleteOptions{})
+	IgnoreNotFoundErr(err)
+
+	// Verify the testing machine has been destroyed
+	By("Verify instance is terminated")
+	err = wait.Poll(PollInterval, PoolTimeout, func() (bool, error) {
+		_, err := f.CAPIClient.ClusterV1alpha1().Machines(machine.Namespace).Get(machine.Name, metav1.GetOptions{})
+		if err == nil {
+			log.Info("Waiting for machine to be deleted")
+			return false, nil
+		}
+		if strings.Contains(err.Error(), "not found") {
+			return true, nil
+		}
+		return false, nil
+	})
+	IgnoreNotFoundErr(err)
+
+	if client != nil {
+		err = wait.Poll(PollInterval, PoolTimeout, func() (bool, error) {
+			log.Info("Waiting for instance to be terminated")
+			runningInstances, err := client.GetRunningInstances(machine)
+			if err != nil {
+				return false, fmt.Errorf("unable to get running instances from aws: %v", err)
+			}
+			runningInstancesLen := len(runningInstances)
+			if runningInstancesLen > 0 {
+				log.Info("Machine is running")
+				return false, nil
+			}
+			return true, nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+	}
+}
+
+func (f *Framework) waitForMachineToRun(machine *clusterv1alpha1.Machine, client CloudProviderClient) {
+	By(fmt.Sprintf("Waiting for %q machine", machine.Name))
+	// Verify machine has been deployed
+	err := wait.Poll(PollInterval, TimeoutPoolMachineRunningInterval, func() (bool, error) {
+		if _, err := f.CAPIClient.ClusterV1alpha1().Machines(machine.Namespace).Get(machine.Name, metav1.GetOptions{}); err != nil {
+			log.Infof("Waiting for '%v/%v' machine to be created", machine.Namespace, machine.Name)
+			return false, nil
+		}
+		return true, nil
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Verify machine's underlying instance is running")
+	err = wait.Poll(PollInterval, PoolTimeout, func() (bool, error) {
+		log.Info("Waiting for instance to come up")
+		runningInstances, err := client.GetRunningInstances(machine)
+		if err != nil {
+			return false, fmt.Errorf("unable to get running instances from aws: %v", err)
+		}
+		runningInstancesLen := len(runningInstances)
+		if runningInstancesLen == 1 {
+			log.Info("Machine is running")
+			return true, nil
+		}
+		if runningInstancesLen > 1 {
+			return false, fmt.Errorf("Found %q instances instead of one", runningInstancesLen)
+		}
+		return false, nil
+	})
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func (f *Framework) waitForMachineToTerminate(machine *clusterv1alpha1.Machine, client CloudProviderClient) error {
+	By("Verify machine's underlying instance is not running")
+	err := wait.Poll(PollInterval, PoolTimeout, func() (bool, error) {
+		log.Info("Waiting for instance to terminate")
+		runningInstances, err := client.GetRunningInstances(machine)
+		if err != nil {
+			return false, fmt.Errorf("unable to get running instances from cloud provider: %v", err)
+		}
+		runningInstancesLen := len(runningInstances)
+		if runningInstancesLen > 1 {
+			return false, fmt.Errorf("Found %q running instances for %q", runningInstancesLen, machine.Name)
+		}
+		return true, nil
+	})
+	// We need to allow to follow
+	if err != nil {
+		log.Info("unable to wait for instance(s) to terminate: %v", err)
+		return err
+	}
+
+	By(fmt.Sprintf("Waiting for %q machine object to be deleted", machine.Name))
+	// Verify machine has been deployed
+	err = wait.Poll(PollInterval, TimeoutPoolMachineRunningInterval, func() (bool, error) {
+		if _, err := f.CAPIClient.ClusterV1alpha1().Machines(machine.Namespace).Get(machine.Name, metav1.GetOptions{}); err != nil {
+			log.Infof("err: %v", err)
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		log.Info("unable to wait for machine to get deleted: %v", err)
+		return err
+	}
+	return nil
+}
+
+func (f *Framework) CreateMachineAndWait(machine *clusterv1alpha1.Machine, client CloudProviderClient) {
+	By(fmt.Sprintf("Creating %q machine", machine.Name))
+	err := wait.Poll(PollInterval, PoolTimeout, func() (bool, error) {
+		_, err := f.CAPIClient.ClusterV1alpha1().Machines(machine.Namespace).Create(machine)
+		if err != nil {
+			log.Infof("can't create machine: %v", err)
+			return false, nil
+		}
+		return true, nil
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	f.waitForMachineToRun(machine, client)
+}
+
+func (f *Framework) CreateMachineSetAndWait(machineset *clusterv1alpha1.MachineSet, client CloudProviderClient) {
+	By(fmt.Sprintf("Creating %q machineset", machineset.Name))
+	err := wait.Poll(PollInterval, PoolTimeout, func() (bool, error) {
+		_, err := f.CAPIClient.ClusterV1alpha1().MachineSets(machineset.Namespace).Create(machineset)
+		if err != nil {
+			log.Infof("can't create machineset: %v", err)
+			return false, nil
+		}
+		return true, nil
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	// Verify machineset has been deployed
+	err = wait.Poll(PollInterval, TimeoutPoolMachineRunningInterval, func() (bool, error) {
+		if _, err := f.CAPIClient.ClusterV1alpha1().MachineSets(machineset.Namespace).Get(machineset.Name, metav1.GetOptions{}); err != nil {
+			log.Infof("Waiting for machineset to be created: %v", err)
+			return false, nil
+		}
+		return true, nil
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Verify machineset's underlying instances is running")
+	machines, err := f.CAPIClient.ClusterV1alpha1().Machines(machineset.Namespace).List(metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(machineset.Spec.Selector.MatchLabels).String(),
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	for _, machine := range machines.Items {
+		f.waitForMachineToRun(&machine, client)
+	}
+}
+
+func (f *Framework) DeleteMachineSetAndWait(machineset *clusterv1alpha1.MachineSet, client CloudProviderClient) error {
+	By("Get all machineset's machines")
+	machines, err := f.CAPIClient.ClusterV1alpha1().Machines(machineset.Namespace).List(metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(machineset.Spec.Selector.MatchLabels).String(),
+	})
+	if err != nil {
+		return err
+	}
+
+	By(fmt.Sprintf("Deleting %q machineset", machineset.Name))
+	err = f.CAPIClient.ClusterV1alpha1().MachineSets(machineset.Namespace).Delete(machineset.Name, &metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+
+	By("Waiting for all machines to be deleted")
+	for _, machine := range machines.Items {
+		f.waitForMachineToTerminate(&machine, client)
+		// TODO(jchaloup): run it one more time depending on the error returned
+	}
+
+	err = wait.Poll(PollInterval, PoolTimeout, func() (bool, error) {
+		_, err := f.CAPIClient.ClusterV1alpha1().MachineSets(machineset.Namespace).Get(machineset.Name, metav1.GetOptions{})
+		if err != nil {
+			if strings.Contains(err.Error(), "not found") {
+				return true, nil
+			}
+			return false, nil
+		}
+		return true, nil
+	})
+	return err
+}
+
+func (f *Framework) WaitForNodesToGetReady() {
+	err := wait.Poll(PollNodeInterval, PoolNodesReadyTimeout, func() (bool, error) {
+		items, err := f.KubeClient.CoreV1().Nodes().List(metav1.ListOptions{})
+		if err != nil {
+			return false, fmt.Errorf("unable to list nodes: %v", err)
+		}
+		if len(items.Items) < 2 {
+			log.Infof("Waiting for both nodes to come up, have %v", len(items.Items))
+			return false, nil
+		}
+		allNodesReady := true
+		for _, node := range items.Items {
+			for _, condition := range node.Status.Conditions {
+				if condition.Type != apiv1.NodeReady {
+					continue
+				}
+				if condition.Status != apiv1.ConditionTrue {
+					log.Infof("Node %q not ready", node.Name)
+					allNodesReady = false
+				} else {
+					log.Infof("Node %q is ready", node.Name)
+				}
+				break
+			}
+		}
+
+		if !allNodesReady {
+			return false, nil
+		}
+
+		return true, nil
+	})
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func ReadKubeconfigFromServer(sshuser, sshhost, prkey string) (string, error) {
+	fp, err := os.Open(prkey)
+	if err != nil {
+		return "", fmt.Errorf("unable to open id_rsa file: %v", err)
+	}
+	defer fp.Close()
+
+	buf, err := ioutil.ReadAll(fp)
+	if err != nil {
+		return "", fmt.Errorf("unable to read id_rsa file: %v", err)
+	}
+
+	key, err := ssh.ParsePrivateKey(buf)
+	if err != nil {
+		return "", fmt.Errorf("unable to parse private key: %v", err)
+	}
+
+	config := &ssh.ClientConfig{
+		User: sshuser,
+		Auth: []ssh.AuthMethod{
+			ssh.PublicKeys(key),
+		},
+		HostKeyCallback: func(hostname string, remote net.Addr, key ssh.PublicKey) error {
+			return nil
+		},
+	}
+
+	client, err := ssh.Dial("tcp", sshhost+":22", config)
+	if err != nil {
+		return "", fmt.Errorf("failed to dial: " + err.Error())
+	}
+
+	session, err := client.NewSession()
+	if err != nil {
+		return "", fmt.Errorf("failed to create session: " + err.Error())
+	}
+	defer session.Close()
+
+	var b bytes.Buffer
+	var se bytes.Buffer
+	session.Stdout = &b
+	session.Stderr = &se
+	if err := session.Run("sudo cat /root/.kube/config"); err != nil {
+		return "", fmt.Errorf("failed to collect kubeconfig: %v, %v", err.Error(), se.String())
+	}
+	return b.String(), nil
+}
+
+func (f *Framework) GetMasterMachineRestConfig(masterMachine *clusterv1alpha1.Machine, client CloudProviderClient) (*rest.Config, error) {
+	var masterPublicDNSName string
+	err := wait.Poll(PollInterval, TimeoutPoolMachineRunningInterval, func() (bool, error) {
+		var err error
+		masterPublicDNSName, err = client.GetPublicDNSName(masterMachine)
+		if err != nil {
+			log.Infof("Unable to collect master public DNS name: %v", err)
+			return false, nil
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var masterKubeconfig string
+	err = wait.Poll(PollInterval, PoolKubeConfigTimeout, func() (bool, error) {
+		log.Infof("Pulling kubeconfig from %v:8443", masterPublicDNSName)
+		var err error
+		masterKubeconfig, err = ReadKubeconfigFromServer("ec2-user", masterPublicDNSName, f.SSHKey)
+		if err != nil {
+			log.Infof("Unable to pull kubeconfig: %v", err)
+			return false, nil
+		}
+
+		return true, nil
+	})
+
+	log.Infof("Master running on https://" + masterPublicDNSName + ":8443")
+
+	config, err := clientcmd.Load([]byte(masterKubeconfig))
+	if err != nil {
+		return nil, err
+	}
+	config.Clusters["kubernetes"].Server = "https://" + masterPublicDNSName + ":8443"
+	return clientcmd.NewDefaultClientConfig(*config, &clientcmd.ConfigOverrides{}).ClientConfig()
+}
+
+type machineToDelete struct {
+	machine   *clusterv1alpha1.Machine
+	framework *Framework
+	client    CloudProviderClient
+}
+
+type machinesetToDelete struct {
+	machineset *clusterv1alpha1.MachineSet
+	framework  *Framework
+	client     CloudProviderClient
+}
+
+type MachinesToDelete struct {
+	machines    []machineToDelete
+	machinesets []machinesetToDelete
+}
+
+func InitMachinesToDelete() *MachinesToDelete {
+	return &MachinesToDelete{
+		machines:    make([]machineToDelete, 0),
+		machinesets: make([]machinesetToDelete, 0),
+	}
+}
+
+func (m *MachinesToDelete) AddMachine(machine *clusterv1alpha1.Machine, framework *Framework, client CloudProviderClient) {
+	m.machines = append(m.machines, machineToDelete{machine: machine, framework: framework, client: client})
+}
+
+func (m *MachinesToDelete) AddMachineSet(machineset *clusterv1alpha1.MachineSet, framework *Framework, client CloudProviderClient) {
+	m.machinesets = append(m.machinesets, machinesetToDelete{machineset: machineset, framework: framework, client: client})
+}
+
+func (m *MachinesToDelete) Delete() {
+	for _, item := range m.machines {
+		item.framework.DeleteMachineAndWait(item.machine, item.client)
+	}
+
+	for _, item := range m.machinesets {
+		item.framework.DeleteMachineSetAndWait(item.machineset, item.client)
+	}
+}

--- a/test/machines/awsclient.go
+++ b/test/machines/awsclient.go
@@ -1,0 +1,61 @@
+package machines
+
+import (
+	"fmt"
+
+	machineutils "sigs.k8s.io/cluster-api-provider-aws/cloud/aws/actuators/machine"
+	awsclient "sigs.k8s.io/cluster-api-provider-aws/cloud/aws/client"
+	clusterv1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+)
+
+type awsClientWrapper struct {
+	client awsclient.Client
+}
+
+func (client *awsClientWrapper) GetRunningInstances(machine *clusterv1alpha1.Machine) ([]interface{}, error) {
+	runningInstances, err := machineutils.GetRunningInstances(machine, client.client)
+	if err != nil {
+		return nil, err
+	}
+
+	var instances []interface{}
+	for _, instance := range runningInstances {
+		instances = append(instances, instance)
+	}
+
+	return instances, nil
+}
+
+func (client *awsClientWrapper) GetPublicDNSName(machine *clusterv1alpha1.Machine) (string, error) {
+	runningInstances, err := machineutils.GetRunningInstances(machine, client.client)
+	if err != nil {
+		return "", err
+	}
+
+	if len(runningInstances) == 0 {
+		return "", fmt.Errorf("no running machine instance found")
+	}
+
+	if *runningInstances[0].PublicDnsName == "" {
+		return "", fmt.Errorf("machine instance public DNS name not set")
+	}
+
+	return *runningInstances[0].PublicDnsName, nil
+}
+
+func (client *awsClientWrapper) GetPrivateIP(machine *clusterv1alpha1.Machine) (string, error) {
+	runningInstances, err := machineutils.GetRunningInstances(machine, client.client)
+	if err != nil {
+		return "", err
+	}
+
+	if len(runningInstances) == 0 {
+		return "", fmt.Errorf("no running machine instance found")
+	}
+
+	if *runningInstances[0].PrivateIpAddress == "" {
+		return "", fmt.Errorf("machine instance public DNS name not set")
+	}
+
+	return *runningInstances[0].PrivateIpAddress, nil
+}

--- a/test/machines/machines_test.go
+++ b/test/machines/machines_test.go
@@ -2,17 +2,16 @@ package machines
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/common/log"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	// "k8s.io/apimachinery/pkg/util/uuid"
 
 	"sigs.k8s.io/cluster-api-provider-aws/test/framework"
 	"sigs.k8s.io/cluster-api-provider-aws/test/utils"
@@ -21,7 +20,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 
-	machineutils "sigs.k8s.io/cluster-api-provider-aws/cloud/aws/actuators/machine"
 	awsclient "sigs.k8s.io/cluster-api-provider-aws/cloud/aws/client"
 )
 
@@ -40,140 +38,56 @@ func TestCart(t *testing.T) {
 	RunSpecs(t, "Machine Suite")
 }
 
+func createSecretAndWait(f *framework.Framework, secret *apiv1.Secret) {
+	_, err := f.KubeClient.CoreV1().Secrets(secret.Namespace).Create(secret)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = wait.Poll(framework.PollInterval, framework.PoolTimeout, func() (bool, error) {
+		if _, err := f.KubeClient.CoreV1().Secrets(secret.Namespace).Get(secret.Name, metav1.GetOptions{}); err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+	Expect(err).NotTo(HaveOccurred())
+}
+
 var _ = framework.SigKubeDescribe("Machines", func() {
 	f := framework.NewFramework()
 	var err error
 	var testNamespace *apiv1.Namespace
-	var testMachine *clusterv1alpha1.Machine
+
+	machinesToDelete := framework.InitMachinesToDelete()
 
 	BeforeEach(func() {
 		f.BeforeEach()
-		By("Deploy cluster API stack components")
 
-		certsSecret := utils.ClusterAPIServerCertsSecret()
-		_, err = f.KubeClient.CoreV1().Secrets(certsSecret.Namespace).Create(certsSecret)
+		testNamespace = &apiv1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "namespace-" + string(uuid.NewUUID()),
+			},
+		}
+
+		By(fmt.Sprintf("Creating %q namespace", testNamespace.Name))
+		_, err = f.KubeClient.CoreV1().Namespaces().Create(testNamespace)
 		Expect(err).NotTo(HaveOccurred())
 
-		err = wait.Poll(pollInterval, poolTimeout, func() (bool, error) {
-			if _, err := f.KubeClient.CoreV1().Secrets(certsSecret.Namespace).Get(certsSecret.Name, metav1.GetOptions{}); err != nil {
-				return false, nil
-			}
-			return true, nil
-		})
-		Expect(err).NotTo(HaveOccurred())
-
-		apiAPIService := utils.ClusterAPIAPIService()
-		_, err = f.APIRegistrationClient.Apiregistration().APIServices().Create(apiAPIService)
-		Expect(err).NotTo(HaveOccurred())
-
-		apiService := utils.ClusterAPIService()
-		_, err = f.KubeClient.CoreV1().Services(apiService.Namespace).Create(apiService)
-		Expect(err).NotTo(HaveOccurred())
-
-		clusterAPIDeployment := utils.ClusterAPIDeployment()
-		_, err = f.KubeClient.AppsV1beta2().Deployments(clusterAPIDeployment.Namespace).Create(clusterAPIDeployment)
-		Expect(err).NotTo(HaveOccurred())
-
-		clusterAPIControllersDeployment := utils.ClusterAPIControllersDeployment()
-		_, err = f.KubeClient.AppsV1beta2().Deployments(clusterAPIDeployment.Namespace).Create(clusterAPIControllersDeployment)
-		Expect(err).NotTo(HaveOccurred())
-
-		clusterAPIRoleBinding := utils.ClusterAPIRoleBinding()
-		_, err = f.KubeClient.RbacV1().RoleBindings(clusterAPIRoleBinding.Namespace).Create(clusterAPIRoleBinding)
-		Expect(err).NotTo(HaveOccurred())
-
-		clusterAPIEtcdCluster := utils.ClusterAPIEtcdCluster()
-		_, err = f.KubeClient.AppsV1beta2().StatefulSets(clusterAPIEtcdCluster.Namespace).Create(clusterAPIEtcdCluster)
-		Expect(err).NotTo(HaveOccurred())
-
-		etcdService := utils.ClusterAPIEtcdService()
-		_, err = f.KubeClient.CoreV1().Services(etcdService.Namespace).Create(etcdService)
-		Expect(err).NotTo(HaveOccurred())
-
-		By("Waiting for cluster API stack to come up")
-		err = wait.Poll(pollInterval, poolClusterAPIDeploymentTimeout, func() (bool, error) {
-			if deployment, err := f.KubeClient.AppsV1beta2().Deployments(clusterAPIDeployment.Namespace).Get(clusterAPIDeployment.Name, metav1.GetOptions{}); err == nil {
-				// Check all the pods are running
-				log.Infof("Waiting for all cluster-api deployment pods to be ready, have %v, expecting 1", deployment.Status.ReadyReplicas)
-				if deployment.Status.ReadyReplicas < 1 {
-					return false, nil
-				}
-				return true, nil
-			}
-
-			return false, nil
-		})
-		Expect(err).NotTo(HaveOccurred())
-
-		By("Cluster API stack deployed")
-
+		f.DeployClusterAPIStack(testNamespace.Name)
 	})
 
 	AfterEach(func() {
-		var err error
-		var foregroundDeletepolicy metav1.DeletionPropagation = "Foreground"
-
-		// Make sure the test machine is deleted before deleting its namespace
-		if testMachine != nil {
-			log.Infof(testMachine.Name+": %#v", testMachine)
-			By("Deleting testing machine")
-			err = f.CAPIClient.ClusterV1alpha1().Machines(testMachine.Namespace).Delete(testMachine.Name, &metav1.DeleteOptions{})
-			framework.IgnoreNotFoundErr(err)
-
-			// Verify the testing machine has been destroyed
-			err = wait.Poll(pollInterval, timeoutPoolMachineRunningInterval, func() (bool, error) {
-				_, err := f.CAPIClient.ClusterV1alpha1().Machines(testMachine.Namespace).Get(testMachine.Name, metav1.GetOptions{})
-				if err == nil {
-					log.Info("Waiting for machine to be deleted")
-					return false, nil
-				}
-				if strings.Contains(err.Error(), "not found") {
-					return true, nil
-				}
-				return false, nil
-			})
-			framework.IgnoreNotFoundErr(err)
-		}
+		// Make sure all machine(set)s are deleted before deleting its namespace
+		machinesToDelete.Delete()
 
 		if testNamespace != nil {
+			f.DestroyClusterAPIStack(testNamespace.Name)
 			log.Infof(testNamespace.Name+": %#v", testNamespace)
 			By(fmt.Sprintf("Destroying %q namespace", testNamespace.Name))
-			err = f.KubeClient.CoreV1().Namespaces().Delete(testNamespace.Name, &metav1.DeleteOptions{})
-			framework.IgnoreNotFoundErr(err)
+			f.KubeClient.CoreV1().Namespaces().Delete(testNamespace.Name, &metav1.DeleteOptions{})
+			// Ignore namespaces that are not deleted so other specs can be run.
+			// Every spec runs in its own namespaces so it's enough to make sure
+			// namespaces does not inluence each other
 		}
-
-		etcdService := utils.ClusterAPIEtcdService()
-		err = f.KubeClient.CoreV1().Services(etcdService.Namespace).Delete(etcdService.Name, &metav1.DeleteOptions{})
-		framework.IgnoreNotFoundErr(err)
-
-		clusterAPIEtcdCluster := utils.ClusterAPIEtcdCluster()
-		err = f.KubeClient.AppsV1beta2().StatefulSets(clusterAPIEtcdCluster.Namespace).Delete(clusterAPIEtcdCluster.Name, &metav1.DeleteOptions{PropagationPolicy: &foregroundDeletepolicy})
-		framework.IgnoreNotFoundErr(err)
-
-		clusterAPIRoleBinding := utils.ClusterAPIRoleBinding()
-		err = f.KubeClient.RbacV1().RoleBindings(clusterAPIRoleBinding.Namespace).Delete(clusterAPIRoleBinding.Name, &metav1.DeleteOptions{})
-		framework.IgnoreNotFoundErr(err)
-
-		clusterAPIControllersDeployment := utils.ClusterAPIControllersDeployment()
-		err = f.KubeClient.AppsV1beta2().Deployments(clusterAPIControllersDeployment.Namespace).Delete(clusterAPIControllersDeployment.Name, &metav1.DeleteOptions{PropagationPolicy: &foregroundDeletepolicy})
-		framework.IgnoreNotFoundErr(err)
-
-		clusterAPIDeployment := utils.ClusterAPIDeployment()
-		err = f.KubeClient.AppsV1beta2().Deployments(clusterAPIDeployment.Namespace).Delete(clusterAPIDeployment.Name, &metav1.DeleteOptions{PropagationPolicy: &foregroundDeletepolicy})
-		framework.IgnoreNotFoundErr(err)
-
-		apiService := utils.ClusterAPIService()
-		err = f.KubeClient.CoreV1().Services(apiService.Namespace).Delete(apiService.Name, &metav1.DeleteOptions{})
-		framework.IgnoreNotFoundErr(err)
-
-		apiAPIService := utils.ClusterAPIAPIService()
-		err = f.APIRegistrationClient.Apiregistration().APIServices().Delete(apiAPIService.Name, &metav1.DeleteOptions{})
-		framework.IgnoreNotFoundErr(err)
-
-		certsSecret := utils.ClusterAPIServerCertsSecret()
-		err = f.KubeClient.CoreV1().Secrets(certsSecret.Namespace).Delete(certsSecret.Name, &metav1.DeleteOptions{})
-		framework.IgnoreNotFoundErr(err)
-
+		// it's assumed the cluster API is completely destroyed
 	})
 
 	// Any of the tests run assumes the cluster-api stack is already deployed.
@@ -181,29 +95,10 @@ var _ = framework.SigKubeDescribe("Machines", func() {
 	// of the same cluster-api stack. Once the machine, resp. machineset objects
 	// are defined through CRD, we can relax the restriction.
 	Context("AWS actuator", func() {
-
 		It("Can create AWS instances", func() {
-			testNamespace = &apiv1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "namespace-" + string(uuid.NewUUID()),
-				},
-			}
-
-			By(fmt.Sprintf("Creating %q namespace", testNamespace.Name))
-			_, err = f.KubeClient.CoreV1().Namespaces().Create(testNamespace)
-			Expect(err).NotTo(HaveOccurred())
 
 			awsCredSecret := utils.GenerateAwsCredentialsSecretFromEnv(awsCredentialsSecretName, testNamespace.Name)
-			_, err = f.KubeClient.CoreV1().Secrets(awsCredSecret.Namespace).Create(awsCredSecret)
-			Expect(err).NotTo(HaveOccurred())
-
-			err = wait.Poll(pollInterval, poolTimeout, func() (bool, error) {
-				if _, err := f.KubeClient.CoreV1().Secrets(awsCredSecret.Namespace).Get(awsCredSecret.Name, metav1.GetOptions{}); err != nil {
-					return false, nil
-				}
-				return true, nil
-			})
-			Expect(err).NotTo(HaveOccurred())
+			createSecretAndWait(f, awsCredSecret)
 
 			clusterID := framework.ClusterID
 			if clusterID == "" {
@@ -228,81 +123,180 @@ var _ = framework.SigKubeDescribe("Machines", func() {
 				},
 			}
 
-			By(fmt.Sprintf("Creating %q cluster", cluster.Name))
-			err = wait.Poll(pollInterval, poolTimeout, func() (bool, error) {
-				_, err = f.CAPIClient.ClusterV1alpha1().Clusters(cluster.Namespace).Create(cluster)
-				if err != nil {
-					return false, nil
-				}
-				return true, nil
-			})
+			f.CreateClusterAndWait(cluster)
 
-			Expect(err).NotTo(HaveOccurred())
-			err = wait.Poll(pollInterval, poolTimeout, func() (bool, error) {
-				_, err := f.CAPIClient.ClusterV1alpha1().Clusters(cluster.Namespace).Get(cluster.Name, metav1.GetOptions{})
-				if err != nil {
-					return false, nil
-				}
-				return true, nil
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			testMachine = utils.TestingMachine(awsCredSecret.Name, cluster.Name, cluster.Namespace)
-			By(fmt.Sprintf("Creating %q machine", testMachine.Name))
-			_, err = f.CAPIClient.ClusterV1alpha1().Machines(testMachine.Namespace).Create(testMachine)
-			Expect(err).NotTo(HaveOccurred())
-
-			// Verify cluster and machine have been deployed
-			err = wait.Poll(pollInterval, timeoutPoolMachineRunningInterval, func() (bool, error) {
-				if _, err := f.CAPIClient.ClusterV1alpha1().Machines(testMachine.Namespace).Get(testMachine.Name, metav1.GetOptions{}); err != nil {
-					log.Info("Waiting for cluster and machine to be created")
-					return false, nil
-				}
-				return true, nil
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Verify AWS instance is running")
+			// Create/delete a single machine, test instance is provisioned/terminated
+			testMachine := utils.TestingMachine(awsCredSecret.Name, cluster.Name, cluster.Namespace)
 			awsClient, err := awsclient.NewClient(f.KubeClient, awsCredSecret.Name, awsCredSecret.Namespace, region)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = wait.Poll(pollInterval, poolTimeout, func() (bool, error) {
-				log.Info("Waiting for aws instances to come up")
-				runningInstances, err := machineutils.GetRunningInstances(testMachine, awsClient)
+			f.CreateMachineAndWait(testMachine, &awsClientWrapper{client: awsClient})
+			machinesToDelete.AddMachine(testMachine, f, &awsClientWrapper{client: awsClient})
+
+			// TODO(jchaloup): Run some tests here!!! E.g. check for properly set security groups, iam role, tags
+
+			f.DeleteMachineAndWait(testMachine, &awsClientWrapper{client: awsClient})
+		})
+
+		It("Can deploy compute nodes through machineset", func() {
+			// Any controller linking kubernetes node with its machine
+			// needs to run inside the cluster where the node is registered.
+			// Which means the cluster API stack needs to be deployed in the same
+			// cluster in order to list machine object(s) defining the node.
+			//
+			// One could run the controller inside the current cluster and have
+			// new nodes join the cluster assumming the cluster was created with kubeadm
+			// and the bootstrapping token is known in advance. Though, in case of AWS
+			// all instances must live in the same vpc, otherwise additional configuration
+			// of the underlying environment is required. Which does not have to be
+			// available.
+
+			// Thus:
+			// 1. create testing cluster (deploy master node)
+			// 2. deploy the cluster-api inside the master node
+			// 3. deploy machineset with worker nodes
+			// 4. check all worker nodes has compute role and corresponding machines
+			//    are linked to them
+
+			awsCredSecret := utils.GenerateAwsCredentialsSecretFromEnv(awsCredentialsSecretName, testNamespace.Name)
+
+			clusterID := framework.ClusterID
+			if clusterID == "" {
+				clusterID = "cluster-" + string(uuid.NewUUID())
+			}
+
+			cluster := &clusterv1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      clusterID,
+					Namespace: testNamespace.Name,
+				},
+				Spec: clusterv1alpha1.ClusterSpec{
+					ClusterNetwork: clusterv1alpha1.ClusterNetworkingConfig{
+						Services: clusterv1alpha1.NetworkRanges{
+							CIDRBlocks: []string{"10.0.0.1/24"},
+						},
+						Pods: clusterv1alpha1.NetworkRanges{
+							CIDRBlocks: []string{"10.0.0.1/24"},
+						},
+						ServiceDomain: "example.com",
+					},
+				},
+			}
+
+			createSecretAndWait(f, awsCredSecret)
+			f.CreateClusterAndWait(cluster)
+
+			// Create master machine and verify the master node is ready
+			masterUserDataSecret := utils.MasterMachineUserDataSecret("masteruserdatasecret", testNamespace.Name)
+			createSecretAndWait(f, masterUserDataSecret)
+
+			masterMachine := utils.MasterMachine(awsCredSecret.Name, masterUserDataSecret.Name, cluster.Name, cluster.Namespace)
+			awsClient, err := awsclient.NewClient(f.KubeClient, awsCredSecret.Name, awsCredSecret.Namespace, region)
+			Expect(err).NotTo(HaveOccurred())
+			acw := &awsClientWrapper{client: awsClient}
+			f.CreateMachineAndWait(masterMachine, &awsClientWrapper{client: awsClient})
+			machinesToDelete.AddMachine(masterMachine, f, acw)
+
+			By("Collecting master kubeconfig")
+			restConfig, err := f.GetMasterMachineRestConfig(masterMachine, acw)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Load actuator docker image to the master node
+			dnsName, err := acw.GetPublicDNSName(masterMachine)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = f.UploadDockerImageToInstance(f.ActuatorImage, dnsName)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Deploy the cluster API stack inside the master machine
+			clusterFramework := framework.NewFrameworkFromConfig(restConfig)
+			By(fmt.Sprintf("Creating %q namespace", testNamespace.Name))
+			_, err = clusterFramework.KubeClient.CoreV1().Namespaces().Create(testNamespace)
+			Expect(err).NotTo(HaveOccurred())
+
+			clusterFramework.DeployClusterAPIStack(testNamespace.Name)
+
+			By("Deploy worker nodes through machineset")
+			masterPrivateIP, err := acw.GetPrivateIP(masterMachine)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Reuse the namespace, secret and the cluster objects
+			clusterFramework.CreateClusterAndWait(cluster)
+			createSecretAndWait(clusterFramework, awsCredSecret)
+
+			workerUserDataSecret, err := utils.WorkerMachineUserDataSecret("workeruserdatasecret", testNamespace.Name, masterPrivateIP)
+			Expect(err).NotTo(HaveOccurred())
+			createSecretAndWait(clusterFramework, workerUserDataSecret)
+
+			workerMachineSet := utils.WorkerMachineSet(awsCredSecret.Name, workerUserDataSecret.Name, cluster.Name, cluster.Namespace)
+			fmt.Printf("workerMachineSet: %#v\n", workerMachineSet)
+			clusterFramework.CreateMachineSetAndWait(workerMachineSet, acw)
+			machinesToDelete.AddMachineSet(workerMachineSet, clusterFramework, acw)
+
+			By("Checking master and worker nodes are ready")
+			clusterFramework.WaitForNodesToGetReady()
+
+			By("Checking compute node role and node linking")
+			err = wait.Poll(framework.PollInterval, framework.PoolTimeout, func() (bool, error) {
+				items, err := clusterFramework.KubeClient.CoreV1().Nodes().List(metav1.ListOptions{})
 				if err != nil {
-					return false, fmt.Errorf("unable to get running instances from aws: %v", err)
+					return false, fmt.Errorf("unable to list nodes: %v", err)
 				}
-				runningInstancesLen := len(runningInstances)
-				if runningInstancesLen == 1 {
-					log.Info("Machine is running on aws")
-					return true, nil
+
+				var nonMasterNodes []apiv1.Node
+				for _, node := range items.Items {
+					// filter out all nodes with master role (assumming it's always set)
+					if _, isMaster := node.Labels["node-role.kubernetes.io/master"]; isMaster {
+						continue
+					}
+					nonMasterNodes = append(nonMasterNodes, node)
 				}
-				if runningInstancesLen > 1 {
-					return false, fmt.Errorf("Found %q instances instead of one", runningInstancesLen)
+
+				machines, err := clusterFramework.CAPIClient.ClusterV1alpha1().Machines(workerMachineSet.Namespace).List(metav1.ListOptions{
+					LabelSelector: labels.SelectorFromSet(workerMachineSet.Spec.Selector.MatchLabels).String(),
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				matches := make(map[string]string)
+				for _, machine := range machines.Items {
+					if machine.Status.NodeRef != nil {
+						matches[machine.Status.NodeRef.Name] = machine.Name
+					}
 				}
-				return false, nil
+
+				// non-master node, the workerset deploys only compute nodes
+				for _, node := range nonMasterNodes {
+					// check role
+					_, isCompute := node.Labels["node-role.kubernetes.io/compute"]
+					if !isCompute {
+						log.Infof("node %q does not have the compute role assigned", node.Name)
+						return false, nil
+					}
+					log.Infof("node %q role set to 'node-role.kubernetes.io/compute'", node.Name)
+					// check node linking
+
+					// If there is the same number of machines are compute nodes,
+					// each node has to have a machine that refers the node.
+					// So it's enough to check each node has its machine linked.
+					matchingMachine, found := matches[node.Name]
+					if !found {
+						log.Infof("node %q is not linked with a machine", node.Name)
+						return false, nil
+					}
+					log.Infof("node %q is linked with %q machine", node.Name, matchingMachine)
+				}
+
+				return true, nil
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Verify AWS instance is terminated")
-			err = f.CAPIClient.ClusterV1alpha1().Machines(testMachine.Namespace).Delete(testMachine.Name, &metav1.DeleteOptions{})
-			framework.IgnoreNotFoundErr(err)
-
-			// Verify the testing machine has been destroyed
-			err = wait.Poll(pollInterval, poolTimeout, func() (bool, error) {
-				_, err := f.CAPIClient.ClusterV1alpha1().Machines(testMachine.Namespace).Get(testMachine.Name, metav1.GetOptions{})
-				if err == nil {
-					log.Info("Waiting for machine to be deleted")
-					return false, nil
-				}
-				if strings.Contains(err.Error(), "not found") {
-					return true, nil
-				}
-				return false, nil
-			})
-			framework.IgnoreNotFoundErr(err)
-
+			By("Destroying worker machines")
+			// Let it fail and continue (assuming all instances gets removed out of the e2e)
+			clusterFramework.DeleteMachineSetAndWait(workerMachineSet, acw)
+			By("Destroying master machine")
+			f.DeleteMachineAndWait(masterMachine, acw)
 		})
+
 	})
 
 })

--- a/test/uploadDockerImages.sh
+++ b/test/uploadDockerImages.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+image=${1}
+sshhost=${2}
+sshkey=${3}
+
+#docker save docker.io/centos:centos7 | bzip2 | ssh -i /home/jchaloup/.ssh/libra.pem ec2-user@ec2-34-200-213-218.compute-1.amazonaws.com 'bunzip2 > /tmp/sideimage && sudo docker image import /tmp/sideimage docker.io/centos:centos7'
+docker save ${image} | bzip2 | ssh -i ${sshkey} ec2-user@${sshhost} "bunzip2 > /tmp/tempimage.bz2 && sudo docker load -i /tmp/tempimage.bz2"
+echo "image: $image"
+echo "sshhost: $sshhost"

--- a/test/utils/manifests.go
+++ b/test/utils/manifests.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"text/template"
 
 	appsv1beta2 "k8s.io/api/apps/v1beta2"
 	apiv1 "k8s.io/api/core/v1"
@@ -13,6 +14,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/cert/triple"
 	apiregistrationv1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 	awsclient "sigs.k8s.io/cluster-api-provider-aws/cloud/aws/client"
 	clusterapiaproviderawsv1alpha1 "sigs.k8s.io/cluster-api-provider-aws/cloud/aws/providerconfig"
@@ -34,126 +37,69 @@ func GenerateAwsCredentialsSecretFromEnv(secretName, namespace string) *apiv1.Se
 	}
 }
 
-const (
-	tlscrt = `-----BEGIN CERTIFICATE-----
-MIIDYDCCAkigAwIBAgIIOtBgHbOzgecwDQYJKoZIhvcNAQELBQAwKzEpMCcGA1UE
-AxMgY2x1c3RlcmFwaS1jZXJ0aWZpY2F0ZS1hdXRob3JpdHkwHhcNMTgwODA5MTQ0
-MTU1WhcNMTkwODA5MTQ0MTU1WjAhMR8wHQYDVQQDExZjbHVzdGVyYXBpLmRlZmF1
-bHQuc3ZjMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0C7AVOjCcnLp
-Fx+JYzCrcaBGdzE34TylVM1XQha+du82fTv7qD0Y/wTaNv0eZmaH2IcuJ9ynGwIR
-Zm3V428uls+MiAN9d8jUWoq3B/DiUZ1dDPCRYwvqTT02O70GF6Fe0jFMqJU5I9f2
-OM99iyP9tiXYC423kBPL7m7d9TLXHKkhvFdFlUKZZI2kI47/oIbkm6UVwnFOJo47
-zsa8T+jw6QHPmAvpigX1PpBLjyjkXbgWdrgI5rejiSVs9LIu0klFD/CsLR0o/F2x
-9qkofc8f1HRXxLNlq9JuLB0BgYgxpIjBoZ5oLrbgxk2zuVOsH/6Kms3HW9PlWoxh
-PiVoBa5EJQIDAQABo4GRMIGOMA4GA1UdDwEB/wQEAwIFoDATBgNVHSUEDDAKBggr
-BgEFBQcDATBnBgNVHREEYDBeggpjbHVzdGVyYXBpghJjbHVzdGVyYXBpLmRlZmF1
-bHSCFmNsdXN0ZXJhcGkuZGVmYXVsdC5zdmOCJGNsdXN0ZXJhcGkuZGVmYXVsdC5z
-dmMuY2x1c3Rlci5sb2NhbDANBgkqhkiG9w0BAQsFAAOCAQEArZlNH6T0CWrUr8Vm
-xvBkejNTbODsYuuhdqGgs9/KmoqLXSrdjWa++7NciqGsKoDZMIru2wzD84nRHDKR
-5gyByRHF5W583EXQNjwgXxJpWnmlovRikproz99e9XBDG3x3mS9b+JjUbMxOv9oI
-wWfmyH3wHsas3zZCCSis49n3xsARkRY6EswzmGKLno9UYIdnG2DzOe2Jv4N8HeN7
-OLU9tLAiWFDabsnWqvbyOzL3GdjaWfUDjmFhX8EK8+5PMeREwu+GZiO1o1QEV688
-5kzMP+8fwQVTV03vJi7QnhucpOhW0VZfoiOKt0kthPg+2R01p8hwG0qdx+U5kHzT
-T3gOkA==
------END CERTIFICATE-----`
-	tlskey = `-----BEGIN RSA PRIVATE KEY-----
-MIIEpAIBAAKCAQEA0C7AVOjCcnLpFx+JYzCrcaBGdzE34TylVM1XQha+du82fTv7
-qD0Y/wTaNv0eZmaH2IcuJ9ynGwIRZm3V428uls+MiAN9d8jUWoq3B/DiUZ1dDPCR
-YwvqTT02O70GF6Fe0jFMqJU5I9f2OM99iyP9tiXYC423kBPL7m7d9TLXHKkhvFdF
-lUKZZI2kI47/oIbkm6UVwnFOJo47zsa8T+jw6QHPmAvpigX1PpBLjyjkXbgWdrgI
-5rejiSVs9LIu0klFD/CsLR0o/F2x9qkofc8f1HRXxLNlq9JuLB0BgYgxpIjBoZ5o
-Lrbgxk2zuVOsH/6Kms3HW9PlWoxhPiVoBa5EJQIDAQABAoIBAQCw4khA3NP6cnBi
-WUVepgfFr6yvsX4NPn4ro500ZibG31Go7sJQnDkU1YajmkWuNAfQjmtFK1JAvG0U
-XtaRO/KV6Rs6pdyBXn4vwBTsBlwFhHN/fxfI1GLr5cqiz2TRxybN6V19D+1Q6zol
-4waEprv3fAgpKOyC2o83s7Oblur3SaRlaXV33UYU67IhY7YPNUqvmphpyQJUTbEK
-9DsLPQsAKwqEFOGNq5fDCfN4eRc6U5AV5JkKq561OdkC/tbyp/nX0nburkuPtI9f
-F+o3sKZbqY2PPRgCmhXrlSk1mSbFCvu9U/lLyTy6PcSxkf83fMPdP1VwJwwWzjBa
-08DAV9OBAoGBANhuELPuhY9tbCJAVjZH0GwV94yIadtMBnNxdCYdg4Z+bo4UsFO3
-C3LweDbJ6vAWrbKI0tgzvnNpL4Y8E1QI2J6TvQ12z8auCZAR8OJcA+T1EISUgq6j
-FU/VELIRa6gm8CX5WFbIjgfTzpaMn55WZMHSw/TyPuIZEP+UORzVCoZ9AoGBAPY+
-rD/itlrG7INj+f0sTh7CTVcv6IkP5YasoW5/FHRzjuwK9u6dfyVQ04N7f2KnY36k
-ezdu2w9G/7YA6QdklCPGDWmPrcDDeBaMeNL/TOc3qO1Q6U/jkF/fWuv032ijDCVD
-rz5mM/02tcW8VMrvVgWkLrxUOsr1Ag0yObJtmRzJAoGAWimQH8VQMq4dDC/NOpO0
-SjLki9EQeGE1lsY+4toMvuzQ1bPcuSNaS6nOCtUXYKmx9tx1Kch0oNPDDqLcUnfU
-9ksJySAj8trx9OjkdwhqPumw1eqgfmxGJpnWeLg1JzoBdXBo0s5+DNi6CZHPtUC8
-fNp29AYvGDXlFPQEzvQZjGkCgYBRhtp8pFD/qRCxR66C1eJfaLE2hpQUnQC/H/Sq
-osRg8cmF+PNceSSZdDMzOvYn8YeNbGOnLLq2SilrVs3QNsqdNXtHUdyTD6R4wrVW
-FlSd0N3LBJjabFtmgoqVyJMXD7R7ufcRT8EyuqRf/USNk8QFRiB7FeAJRikRuWlE
-2+hvkQKBgQCE3B4vZKrbUwXuyXnuAiuVFQBSrjVJlpqY38+VucB0UCzUg4BegYCq
-uLVzPuKQRUTVK66PB9KYFsSqGeUsEGpD0pBk3OoqN6Cdio0517IbeSp5tw/JaGnR
-ORj2OTRfjZoPsqrOlUY8A3TVLZc408ECv15PedfW+2TY/2u36XkBFA==
------END RSA PRIVATE KEY-----`
-)
+func ClusterAPIServerAPIServiceObjects(clusterAPINamespace string) (*apiv1.Secret, *apiregistrationv1beta1.APIService, error) {
+	// Copied from the https://github.com/kubernetes-sigs/cluster-api/blob/master/pkg/deployer/clusterapiserver.go#L46 (getApiServerCertsForNamespace)
+	name := "clusterapi"
 
-// ClusterAPIServerCertsSecret builds secret object with tls crt and key
-func ClusterAPIServerCertsSecret() *apiv1.Secret {
+	caKeyPair, err := triple.NewCA(fmt.Sprintf("%s-certificate-authority", name))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create root-ca: %v", err)
+	}
+
+	apiServerKeyPair, err := triple.NewServerKeyPair(
+		caKeyPair,
+		fmt.Sprintf("%s.%s.svc", name, clusterAPINamespace),
+		name,
+		clusterAPINamespace,
+		"cluster.local",
+		[]string{},
+		[]string{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create apiserver key pair: %v", err)
+	}
+
 	return &apiv1.Secret{
-		Type: "kubernetes.io/tls",
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "cluster-apiserver-certs",
-			Namespace: "default",
-			Labels: map[string]string{
-				"api":       "clusterapi",
-				"apiserver": "true",
+			Type: "kubernetes.io/tls",
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster-apiserver-certs",
+				Namespace: clusterAPINamespace,
+				Labels: map[string]string{
+					"api":       "clusterapi",
+					"apiserver": "true",
+				},
 			},
-		},
-		Data: map[string][]byte{
-			"tls.crt": []byte(tlscrt),
-			"tls.key": []byte(tlskey),
-		},
-	}
+			Data: map[string][]byte{
+				"tls.crt": cert.EncodeCertPEM(apiServerKeyPair.Cert),
+				"tls.key": cert.EncodePrivateKeyPEM(apiServerKeyPair.Key),
+			},
+		}, &apiregistrationv1beta1.APIService{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "v1alpha1.cluster.k8s.io",
+				Namespace: clusterAPINamespace,
+				Labels: map[string]string{
+					"api":       "clusterapi",
+					"apiserver": "true",
+				},
+			},
+			Spec: apiregistrationv1beta1.APIServiceSpec{
+				Version:              "v1alpha1",
+				Group:                "cluster.k8s.io",
+				GroupPriorityMinimum: 2000,
+				Service: &apiregistrationv1beta1.ServiceReference{
+					Name:      "clusterapi",
+					Namespace: clusterAPINamespace,
+				},
+				VersionPriority: 10,
+				CABundle:        cert.EncodeCertPEM(caKeyPair.Cert),
+			},
+		}, nil
 }
 
-const (
-	cabundle = `-----BEGIN CERTIFICATE-----
-MIIC9DCCAdygAwIBAgIBADANBgkqhkiG9w0BAQsFADArMSkwJwYDVQQDEyBjbHVz
-dGVyYXBpLWNlcnRpZmljYXRlLWF1dGhvcml0eTAeFw0xODA4MDkxNDQxNTVaFw0y
-ODA4MDYxNDQxNTVaMCsxKTAnBgNVBAMTIGNsdXN0ZXJhcGktY2VydGlmaWNhdGUt
-YXV0aG9yaXR5MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5u7BGB85
-+3OOCHWCBB6+XSRNCqzXSk0BPZ9b0lnGAdeK4wqshvIHagCvXtFdLwCms1PWo3G0
-T3a1chzMPRPSpWMmrWCz/Hnms8n9FEcf/ADbWrl8Wb9jBelseXiPKgraV8vzz7LG
-rot6LWd4F5TiJ8Canhiwu1jOTd+ab4tqsFCSNBd4sMw4cihz3cW6h6vfNRmgeCiG
-5zxKdQNPMOO+gMkB6IQvOpnLvYD1lCNDLLv4ssJ6w1mLeTvF0OAOp95lnOy41KIJ
-V+TZTiLdvyhWQ2bDzL/loo6+GIBy5bLxgAWqTpd7nU94IsXJnCSPGm3S5N//zN2R
-ysM55ryR6ULZZQIDAQABoyMwITAOBgNVHQ8BAf8EBAMCAqQwDwYDVR0TAQH/BAUw
-AwEB/zANBgkqhkiG9w0BAQsFAAOCAQEA2Br70cLOPW3X7lzJupe8ZAMC8RN+1KpN
-1/1v6+R5Mq0KgJQsNqgP/YAdTtaoqTlhea2qLzpOH0f4yMekarHOweqf5K/Rp/7h
-Mo4ocOVTfmw9+Vffx6OQTxqM6uvK3IwzfPIkna1alKzANiqVC9Q844Ls0n6D2Ck5
-+n9Ro6MGywX2nEoP7vlRGvpwz11WFcqcOMjwY5uiIiuIR8hS6jNJbz9H/0Ng50wz
-NHRNsymZGoLKX00An2rUVy0NwNYr400GEQBuppKl4rZ6l5PTx7fh7/3wAN3JfXE0
-P66QocO5ZrXAqwezokmymjx31khIgFvNl8Tc1WhEf7MOmdSwWnQCPw==
------END CERTIFICATE-----`
-)
-
-func ClusterAPIAPIService() *apiregistrationv1beta1.APIService {
-	return &apiregistrationv1beta1.APIService{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "v1alpha1.cluster.k8s.io",
-			Namespace: "default",
-			Labels: map[string]string{
-				"api":       "clusterapi",
-				"apiserver": "true",
-			},
-		},
-		Spec: apiregistrationv1beta1.APIServiceSpec{
-			Version:              "v1alpha1",
-			Group:                "cluster.k8s.io",
-			GroupPriorityMinimum: 2000,
-			Service: &apiregistrationv1beta1.ServiceReference{
-				Name:      "clusterapi",
-				Namespace: "default",
-			},
-			VersionPriority: 10,
-			CABundle:        []byte(cabundle),
-		},
-	}
-}
-
-func ClusterAPIService() *apiv1.Service {
+func ClusterAPIService(clusterAPINamespace string) *apiv1.Service {
 	return &apiv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "clusterapi",
-			Namespace: "default",
+			Namespace: clusterAPINamespace,
 			Labels: map[string]string{
 				"api":       "clusterapi",
 				"apiserver": "true",
@@ -175,12 +121,12 @@ func ClusterAPIService() *apiv1.Service {
 	}
 }
 
-func ClusterAPIDeployment() *appsv1beta2.Deployment {
+func ClusterAPIDeployment(clusterAPINamespace string) *appsv1beta2.Deployment {
 	var replicas int32 = 1
 	return &appsv1beta2.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "clusterapi-apiserver",
-			Namespace: "default",
+			Namespace: clusterAPINamespace,
 			Labels: map[string]string{
 				"api":       "clusterapi",
 				"apiserver": "true",
@@ -300,12 +246,12 @@ func ClusterAPIDeployment() *appsv1beta2.Deployment {
 	}
 }
 
-func ClusterAPIControllersDeployment() *appsv1beta2.Deployment {
+func ClusterAPIControllersDeployment(clusterAPINamespace string) *appsv1beta2.Deployment {
 	var replicas int32 = 1
 	return &appsv1beta2.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "clusterapi-controllers",
-			Namespace: "default",
+			Namespace: clusterAPINamespace,
 			Labels: map[string]string{
 				"api": "clusterapi",
 			},
@@ -417,6 +363,33 @@ func ClusterAPIControllersDeployment() *appsv1beta2.Deployment {
 								},
 							},
 						},
+						{
+							Name: "nodelink-controller",
+							// TODO(jchaloup): use other than the latest tag
+							Image: "openshift/origin-machine-api-operator:latest",
+							VolumeMounts: []apiv1.VolumeMount{
+								{
+									Name:      "config",
+									MountPath: "/etc/kubernetes",
+								},
+								{
+									Name:      "certs",
+									MountPath: "/etc/ssl/certs",
+								},
+							},
+							Command: []string{"./nodelink-controller"},
+							Args:    []string{"--kubeconfig=/etc/kubernetes/admin.conf"},
+							Resources: apiv1.ResourceRequirements{
+								Requests: apiv1.ResourceList{
+									"cpu":    resource.MustParse("100m"),
+									"memory": resource.MustParse("20Mi"),
+								},
+								Limits: apiv1.ResourceList{
+									"cpu":    resource.MustParse("100m"),
+									"memory": resource.MustParse("30Mi"),
+								},
+							},
+						},
 					},
 					Volumes: []apiv1.Volume{
 						{
@@ -450,7 +423,7 @@ func ClusterAPIControllersDeployment() *appsv1beta2.Deployment {
 	}
 }
 
-func ClusterAPIRoleBinding() *rbacv1.RoleBinding {
+func ClusterAPIRoleBinding(clusterAPINamespace string) *rbacv1.RoleBinding {
 	return &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "clusterapi",
@@ -465,20 +438,20 @@ func ClusterAPIRoleBinding() *rbacv1.RoleBinding {
 			{
 				Kind:      "ServiceAccount",
 				Name:      "default",
-				Namespace: "default",
+				Namespace: clusterAPINamespace,
 			},
 		},
 	}
 }
 
-func ClusterAPIEtcdCluster() *appsv1beta2.StatefulSet {
+func ClusterAPIEtcdCluster(clusterAPINamespace string) *appsv1beta2.StatefulSet {
 	var terminationGracePeriodSeconds int64 = 10
 	var replicas int32 = 1
 	hostPathDirectoryOrCreate := apiv1.HostPathDirectoryOrCreate
 	return &appsv1beta2.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "etcd-clusterapi",
-			Namespace: "default",
+			Namespace: clusterAPINamespace,
 		},
 		Spec: appsv1beta2.StatefulSetSpec{
 			ServiceName: "etcd",
@@ -602,11 +575,11 @@ func ClusterAPIEtcdCluster() *appsv1beta2.StatefulSet {
 	}
 }
 
-func ClusterAPIEtcdService() *apiv1.Service {
+func ClusterAPIEtcdService(clusterAPINamespace string) *apiv1.Service {
 	return &apiv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "etcd-clusterapi-svc",
-			Namespace: "default",
+			Namespace: clusterAPINamespace,
 			Labels: map[string]string{
 				"app": "etcd",
 			},
@@ -721,4 +694,296 @@ func TestingMachine(awsCredentialsSecretName string, clusterID string, namespace
 	}
 
 	return machine
+}
+
+func MasterMachine(awsCredentialsSecretName, masterUserDataSecretName, clusterID, namespace string) *clusterv1alpha1.Machine {
+	publicIP := true
+	machinePc := &clusterapiaproviderawsv1alpha1.AWSMachineProviderConfig{
+		AMI: clusterapiaproviderawsv1alpha1.AWSResourceReference{
+			Filters: []clusterapiaproviderawsv1alpha1.Filter{
+				{
+					Name:   "tag:image_stage",
+					Values: []string{"base"},
+				},
+				{
+					Name:   "tag:operating_system",
+					Values: []string{"rhel"},
+				},
+				{
+					Name:   "tag:ready",
+					Values: []string{"yes"},
+				},
+			},
+		},
+		CredentialsSecret: &apiv1.LocalObjectReference{
+			Name: awsCredentialsSecretName,
+		},
+		InstanceType: "m4.xlarge",
+		Placement: clusterapiaproviderawsv1alpha1.Placement{
+			Region:           "us-east-1",
+			AvailabilityZone: "us-east-1a",
+		},
+		Subnet: clusterapiaproviderawsv1alpha1.AWSResourceReference{
+			Filters: []clusterapiaproviderawsv1alpha1.Filter{
+				{
+					Name:   "tag:Name",
+					Values: []string{fmt.Sprintf("%s-worker-*", clusterID)},
+				},
+			},
+		},
+		SecurityGroups: []clusterapiaproviderawsv1alpha1.AWSResourceReference{
+			{
+				Filters: []clusterapiaproviderawsv1alpha1.Filter{
+					{
+						Name:   "tag:Name",
+						Values: []string{fmt.Sprintf("%s-*", clusterID)},
+					},
+				},
+			},
+		},
+		PublicIP: &publicIP,
+		UserDataSecret: &apiv1.LocalObjectReference{
+			Name: masterUserDataSecretName,
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := providerconfigv1.Encoder.Encode(machinePc, &buf); err != nil {
+		panic(fmt.Errorf("AWSMachineProviderConfig encoding failed: %v", err))
+	}
+
+	randomUUID := string(uuid.NewUUID())
+
+	machine := &clusterv1alpha1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:         clusterID + "-master-machine-" + randomUUID[:6],
+			Namespace:    namespace,
+			GenerateName: "vs-master-",
+			Labels: map[string]string{
+				"sigs.k8s.io/cluster-api-cluster": clusterID,
+			},
+		},
+		Spec: clusterv1alpha1.MachineSpec{
+			ProviderConfig: clusterv1alpha1.ProviderConfig{
+				Value: &runtime.RawExtension{Raw: buf.Bytes()},
+			},
+			Versions: clusterv1alpha1.MachineVersionInfo{
+				Kubelet:      "1.10.1",
+				ControlPlane: "1.10.1",
+			},
+		},
+	}
+
+	return machine
+}
+
+const masterUserDataBlob = `#!/bin/bash
+
+cat <<HEREDOC > /root/user-data.sh
+#!/bin/bash
+
+cat <<EOF > /etc/yum.repos.d/kubernetes.repo
+[kubernetes]
+name=Kubernetes
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+exclude=kube*
+EOF
+setenforce 0
+yum install -y kubelet-1.11.3 kubeadm-1.11.3 kubectl-1.11.3 --disableexcludes=kubernetes
+
+cat <<EOF > /etc/default/kubelet
+KUBELET_KUBEADM_EXTRA_ARGS=--cgroup-driver=systemd
+EOF
+
+echo '1' > /proc/sys/net/bridge/bridge-nf-call-iptables
+
+kubeadm init --apiserver-bind-port 8443 --token 2iqzqm.85bs0x6miyx1nm7l --apiserver-cert-extra-sans=\$(curl -s http://169.254.169.254/latest/meta-data/public-hostname) --apiserver-cert-extra-sans=\$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4) --pod-network-cidr=192.168.0.0/16 -v 6
+
+# Enable networking by default.
+kubectl apply -f https://raw.githubusercontent.com/cloudnativelabs/kube-router/master/daemonset/kubeadm-kuberouter.yaml --kubeconfig /etc/kubernetes/admin.conf
+
+mkdir -p /root/.kube
+cp -i /etc/kubernetes/admin.conf /root/.kube/config
+chown $(id -u):$(id -g) /root/.kube/config
+HEREDOC
+
+bash /root/user-data.sh > /root/user-data.logs
+`
+
+func MasterMachineUserDataSecret(secretName, namespace string) *apiv1.Secret {
+	return &apiv1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			"userData": []byte(masterUserDataBlob),
+		},
+	}
+}
+
+const workerUserDataBlob = `#!/bin/bash
+
+cat <<HEREDOC > /root/user-data.sh
+#!/bin/bash
+
+cat <<EOF > /etc/yum.repos.d/kubernetes.repo
+[kubernetes]
+name=Kubernetes
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+exclude=kube*
+EOF
+setenforce 0
+yum install -y kubelet-1.11.3 kubeadm-1.11.3 --disableexcludes=kubernetes
+
+cat <<EOF > /etc/default/kubelet
+KUBELET_KUBEADM_EXTRA_ARGS=--cgroup-driver=systemd
+EOF
+
+echo '1' > /proc/sys/net/bridge/bridge-nf-call-iptables
+
+kubeadm join {{ .MasterIP }}:8443 --token 2iqzqm.85bs0x6miyx1nm7l --discovery-token-unsafe-skip-ca-verification
+
+HEREDOC
+
+bash /root/user-data.sh > /root/user-data.logs
+`
+
+type userDataParams struct {
+	MasterIP string
+}
+
+func WorkerMachineUserDataSecret(secretName, namespace, masterIP string) (*apiv1.Secret, error) {
+	params := userDataParams{
+		MasterIP: masterIP,
+	}
+	t, err := template.New("workeruserdata").Parse(workerUserDataBlob)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	err = t.Execute(&buf, params)
+	if err != nil {
+		return nil, err
+	}
+
+	return &apiv1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			"userData": []byte(buf.String()),
+		},
+	}, nil
+}
+
+func WorkerMachineSet(awsCredentialsSecretName, workerUserDataSecretName, clusterID, namespace string) *clusterv1alpha1.MachineSet {
+	publicIP := true
+	machinePc := &clusterapiaproviderawsv1alpha1.AWSMachineProviderConfig{
+		AMI: clusterapiaproviderawsv1alpha1.AWSResourceReference{
+			Filters: []clusterapiaproviderawsv1alpha1.Filter{
+				{
+					Name:   "tag:image_stage",
+					Values: []string{"base"},
+				},
+				{
+					Name:   "tag:operating_system",
+					Values: []string{"rhel"},
+				},
+				{
+					Name:   "tag:ready",
+					Values: []string{"yes"},
+				},
+			},
+		},
+		CredentialsSecret: &apiv1.LocalObjectReference{
+			Name: awsCredentialsSecretName,
+		},
+		InstanceType: "m4.xlarge",
+		Placement: clusterapiaproviderawsv1alpha1.Placement{
+			Region:           "us-east-1",
+			AvailabilityZone: "us-east-1a",
+		},
+		Subnet: clusterapiaproviderawsv1alpha1.AWSResourceReference{
+			Filters: []clusterapiaproviderawsv1alpha1.Filter{
+				{
+					Name:   "tag:Name",
+					Values: []string{fmt.Sprintf("%s-worker-*", clusterID)},
+				},
+			},
+		},
+		SecurityGroups: []clusterapiaproviderawsv1alpha1.AWSResourceReference{
+			{
+				Filters: []clusterapiaproviderawsv1alpha1.Filter{
+					{
+						Name:   "tag:Name",
+						Values: []string{fmt.Sprintf("%s-*", clusterID)},
+					},
+				},
+			},
+		},
+		PublicIP: &publicIP,
+		UserDataSecret: &apiv1.LocalObjectReference{
+			Name: workerUserDataSecretName,
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := providerconfigv1.Encoder.Encode(machinePc, &buf); err != nil {
+		panic(fmt.Errorf("AWSMachineProviderConfig encoding failed: %v", err))
+	}
+
+	var replicas int32 = 1
+	randomUUID := string(uuid.NewUUID())
+	return &clusterv1alpha1.MachineSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:         clusterID + "-worker-machineset-" + randomUUID[:6],
+			Namespace:    namespace,
+			GenerateName: clusterID + "-worker-machine-" + randomUUID[:6] + "-",
+			Labels: map[string]string{
+				"sigs.k8s.io/cluster-api-cluster": clusterID,
+			},
+		},
+		Spec: clusterv1alpha1.MachineSetSpec{
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"sigs.k8s.io/cluster-api-machineset": clusterID + "-worker-machineset-" + randomUUID[:6],
+					"sigs.k8s.io/cluster-api-cluster":    clusterID,
+				},
+			},
+			Replicas: &replicas,
+			Template: clusterv1alpha1.MachineTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: clusterID + "-worker-machine-" + randomUUID[:6] + "-",
+					Labels: map[string]string{
+						"sigs.k8s.io/cluster-api-machineset": clusterID + "-worker-machineset-" + randomUUID[:6],
+						"sigs.k8s.io/cluster-api-cluster":    clusterID,
+					},
+				},
+				Spec: clusterv1alpha1.MachineSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"node-role.kubernetes.io/compute": "",
+						},
+					},
+					ProviderConfig: clusterv1alpha1.ProviderConfig{
+						Value: &runtime.RawExtension{Raw: buf.Bytes()},
+					},
+					Versions: clusterv1alpha1.MachineVersionInfo{
+						Kubelet:      "1.10.1",
+						ControlPlane: "1.10.1",
+					},
+				},
+			},
+		},
+	}
 }


### PR DESCRIPTION
- Deploy the nodelink-controller with deploying the cluster API stack.
- Recreate the cluster API stack in random namespaces before a spec is run.
- Testing for nore roles and machine-node matching requires a new cluster to be deployed via the cluster API. Thus, locally build aws actuator image needs to be uploaded to newly provisioned master node.
- Put semantically closed operations into methods/functions so they can be reused in specs.
- Scale down before deleting deployments/statefulset. It can take some time before the deployments/statefullset is actually deleted. New cluster API stack can be deployed even though there are already existing deployments from any previous run as long as there is zero replicas of previously  created pods.
- Some of the code is still aws actuator specific. Left for improvements in upcoming PR(s).

Towards upstream https://github.com/kubernetes-sigs/cluster-api/issues/510