### PR TITLE
Drop -a from go build and go install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ WORKDIR /go/src/sigs.k8s.io/cluster-api-provider-aws
 # e.g. docker build -t <tag> -f <this_Dockerfile> <path_to_cluster-api-aws>
 COPY . .
 
-RUN GOPATH="/go" CGO_ENABLED=0 GOOS=linux go install -a -ldflags '-extldflags "-static"' sigs.k8s.io/cluster-api-provider-aws/cmd/machine-controller
-RUN GOPATH="/go" CGO_ENABLED=0 GOOS=linux go install -a -ldflags '-extldflags "-static"' sigs.k8s.io/cluster-api-provider-aws/vendor/sigs.k8s.io/cluster-api/cmd/controller-manager
+RUN GOPATH="/go" CGO_ENABLED=0 GOOS=linux go install -ldflags '-extldflags "-static"' sigs.k8s.io/cluster-api-provider-aws/cmd/machine-controller
+RUN GOPATH="/go" CGO_ENABLED=0 GOOS=linux go install -ldflags '-extldflags "-static"' sigs.k8s.io/cluster-api-provider-aws/vendor/sigs.k8s.io/cluster-api/cmd/controller-manager
 
 # Final container
 FROM openshift/origin-base

--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,8 @@ generate-mocks:
 	go generate ./cloud/aws/client/
 
 build:
-	CGO_ENABLED=0 go install -a -ldflags '-extldflags "-static"' sigs.k8s.io/cluster-api-provider-aws/cmd/cluster-controller
-	CGO_ENABLED=0 go install -a -ldflags '-extldflags "-static"' sigs.k8s.io/cluster-api-provider-aws/cmd/machine-controller
+	CGO_ENABLED=0 go install -ldflags '-extldflags "-static"' sigs.k8s.io/cluster-api-provider-aws/cmd/cluster-controller
+	CGO_ENABLED=0 go install -ldflags '-extldflags "-static"' sigs.k8s.io/cluster-api-provider-aws/cmd/machine-controller
 
 aws-actuator:
 	go build -o bin/aws-actuator sigs.k8s.io/cluster-api-provider-aws/cmd/aws-actuator

--- a/cmd/aws-actuator/README.md
+++ b/cmd/aws-actuator/README.md
@@ -5,7 +5,7 @@ The command allows to directly interact with the aws actuator.
 ## To build the `aws-actuator` binary:
 
 ```sh
-go build -o bin/aws-actuator -a sigs.k8s.io/cluster-api-provider-aws/cmd/aws-actuator
+go build -o bin/aws-actuator sigs.k8s.io/cluster-api-provider-aws/cmd/aws-actuator
 ```
 
 ## Prerequisities

--- a/cmd/cluster-controller/Dockerfile
+++ b/cmd/cluster-controller/Dockerfile
@@ -20,7 +20,7 @@ WORKDIR /go/src/sigs.k8s.io/cluster-api-provider-aws
 # e.g. docker build -t <tag> -f <this_Dockerfile> <path_to_cluster-api-aws>
 COPY . . 
 
-RUN CGO_ENABLED=0 GOOS=linux go install -a -ldflags '-extldflags "-static"' sigs.k8s.io/cluster-api-provider-aws/cmd/cluster-controller
+RUN CGO_ENABLED=0 GOOS=linux go install -ldflags '-extldflags "-static"' sigs.k8s.io/cluster-api-provider-aws/cmd/cluster-controller
 
 # Final container
 FROM openshift/origin-base


### PR DESCRIPTION
The toolchain will do the right thing and CI jobs are building in a
pristine environment so there's no need to (force) rebuild everything
all of the time.