### PR TITLE
hack/aws-provision.sh: make it runnable from any directory

### DIFF
--- a/hack/aws-provision.sh
+++ b/hack/aws-provision.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+script_dir="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd -P)"
+
 # Your AWS user account
 export TF_VAR_aws_user=$(aws iam get-user | jq --raw-output '.User.UserName')
 
@@ -9,7 +11,8 @@ export TF_VAR_cluster_namespace="dev-${TF_VAR_cluster_name}"
 
 export TF_IN_AUTOMATION="true"
 
-cd ./prebuild
+pushd $script_dir/prebuild
+
 case ${1} in
  "install")
    echo "***  starting terraform with TF_VAR_environment_id=${TF_VAR_environment_id}"


### PR DESCRIPTION
Previously you had to `cd hack` before running `aws-provision.sh`.
This commit allows you to invoke it from anywhere.