### PR TITLE
Terminate instances before destroying vpc

### DIFF
--- a/hack/aws-provision.sh
+++ b/hack/aws-provision.sh
@@ -23,6 +23,14 @@ case ${1} in
    fi
    ;;
  "destroy")
+   # Terminate all running instances in the vpc first
+   VPC_ID=$(terraform output vpc_id || echo "")
+   if [[ "${VPC_ID}" != "" ]]; then
+     instances=$(aws ec2 describe-instances --filters Name=vpc-id,Values=${VPC_ID} | jq '.Reservations[].Instances[].InstanceId' --raw-output || echo "")
+     if [[ "${instances}" != "" ]]; then
+       aws ec2 terminate-instances --instance-ids ${instances} || true
+     fi
+   fi
    terraform destroy -input=false -auto-approve
    ;;
  *)

--- a/hack/prebuild/main.tf
+++ b/hack/prebuild/main.tf
@@ -64,3 +64,8 @@ resource "aws_iam_role" "role" {
 }
 EOF
 }
+
+output "vpc_id" {
+  value       = "${module.vpc.vpc_id}"
+  description = "The ID of the VPC"
+}


### PR DESCRIPTION
E.g. to clean all resources created during CI run. It can happen a Jenkin jobs is aborted or fails and does not clean all running instances created during testing. 