### PR TITLE
Makefile: add Go debug support for local binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+DBG ?= 0
+
+ifeq ($(DBG),1)
+GOGCFLAGS ?= -gcflags=all="-N -l"
+endif
+
 VERSION     ?= $(shell git describe --always --abbrev=7)
 MUTABLE_TAG ?= latest
 IMAGE        = origin-libvirt-machine-controllers
@@ -64,12 +70,12 @@ bin:
 	@mkdir $@
 
 .PHONY: build
-build: | bin ## build binary
-	$(DOCKER_CMD) go install -ldflags '-extldflags "-static"' sigs.k8s.io/cluster-api-provider-aws/cmd/cluster-controller
-	$(DOCKER_CMD) go install -ldflags '-extldflags "-static"' sigs.k8s.io/cluster-api-provider-aws/cmd/machine-controller
+build: ## build binary
+	$(DOCKER_CMD) go install $(GOGCFLAGS) -ldflags '-extldflags "-static"' sigs.k8s.io/cluster-api-provider-aws/cmd/cluster-controller
+	$(DOCKER_CMD) go install $(GOGCFLAGS) -ldflags '-extldflags "-static"' sigs.k8s.io/cluster-api-provider-aws/cmd/machine-controller
 
 aws-actuator:
-	$(DOCKER_CMD) go build -o bin/aws-actuator sigs.k8s.io/cluster-api-provider-aws/cmd/aws-actuator
+	$(DOCKER_CMD) go build $(GOGCFLAGS) -o bin/aws-actuator sigs.k8s.io/cluster-api-provider-aws/cmd/aws-actuator
 
 .PHONY: images
 images: ## Create images


### PR DESCRIPTION
Invoking:

    $ make build DBG=1

or

    $ make aws-actuator DBG=1

will build cmd/cluster-controller, cmd/machine-controller and
bin/aws-actuator with Go debug support. The build rules for those
three binaries are now `go build $(GOGCFLAGS) ...`.

The default value for GOGCFLAGS is -gcflags=all="-N -l", assuming
GOGCFLAGS it not already set in your environment. "all" specifies that
the flags should be applied to all packages (and may rebuild existing
up to date packages); "-N" disables compiler optimisations and "-l"
prevents inlining.

So, to override the defaults:

    $ make build DBG=1 GOGCFLAGS='-gcflags="-N -l"'