### PR TITLE
Load Balancer update

### DIFF
--- a/pkg/apis/awsproviderconfig/v1alpha1/awsmachineproviderconfig_types.go
+++ b/pkg/apis/awsproviderconfig/v1alpha1/awsmachineproviderconfig_types.go
@@ -133,9 +133,9 @@ type AWSMachineProviderConfig struct {
 	// Placement specifies where to create the instance in AWS
 	Placement Placement
 
-	// LoadBalancerIDs is the IDs of the load balancers to which the new instance
+	// LoadBalancerNames is the names of the load balancers to which the new instance
 	// should be added once it is created.
-	LoadBalancerIDs []AWSResourceReference
+	LoadBalancerNames []string
 }
 
 // AWSResourceReference is a reference to a specific AWS resource by ID, ARN, or filters.

--- a/pkg/apis/awsproviderconfig/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/awsproviderconfig/v1alpha1/zz_generated.deepcopy.go
@@ -87,12 +87,10 @@ func (in *AWSMachineProviderConfig) DeepCopyInto(out *AWSMachineProviderConfig) 
 	}
 	in.Subnet.DeepCopyInto(&out.Subnet)
 	out.Placement = in.Placement
-	if in.LoadBalancerIDs != nil {
-		in, out := &in.LoadBalancerIDs, &out.LoadBalancerIDs
-		*out = make([]AWSResourceReference, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+	if in.LoadBalancerNames != nil {
+		in, out := &in.LoadBalancerNames, &out.LoadBalancerNames
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	return
 }


### PR DESCRIPTION
Introduces the capability of adding machines to specified Load Balancers as they are created or updated.

The LoadBalancer field in ProviderConfig is renamed from LoadBalancerIDs to LoadBalancerNames and its type set to string. AWS only allows specifying load balancers by name, and their describe call doesn't allow Filters.

Depends on https://github.com/openshift/cluster-api-provider-aws/pull/81