### PR TITLE
updateMachineStatus: Log changes with ObjectReflectDiff

### DIFF
--- a/pkg/cloud/aws/actuators/machine/actuator.go
+++ b/pkg/cloud/aws/actuators/machine/actuator.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/client-go/kubernetes"
 
 	providerconfigv1 "sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1alpha1"
@@ -134,7 +135,7 @@ func (a *Actuator) updateMachineStatus(machine *clusterv1.Machine, awsStatus *pr
 	}
 
 	if !equality.Semantic.DeepEqual(machine.Status, machineCopy.Status) {
-		glog.Info("machine status has changed, updating")
+		glog.Infof("machine status changed: %s", diff.ObjectReflectDiff(machine.Status, machineCopy.Status))
 		time := metav1.Now()
 		machineCopy.Status.LastUpdated = &time
 


### PR DESCRIPTION
Because logs like:

```console
$ curl -s https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_installer/525/pull-ci-openshift-installer-master-e2e-aws/867/artifacts/e2e-aws/pods/openshift-cluster-api_clusterapi-manager-controllers-76c6686888-brwk4_aws-machine-controller.log.gz | gunzip  | tail -n 11
time="2018-10-24T15:08:11Z" level=debug msg="finished calculating AWS status" controller=awsMachine instanceID=i-0d6c4a1b08ea79f9e machine=openshift-cluster-api/ci-op-kgknj8yp-1d3f3-worker-0-sjvd8
time="2018-10-24T15:08:11Z" level=info msg="machine status has changed, updating" controller=awsMachine instanceID=i-0d6c4a1b08ea79f9e machine=openshift-cluster-api/ci-op-kgknj8yp-1d3f3-worker-0-sjvd8
time="2018-10-24T15:08:12Z" level=debug msg="checking if machine exists" controller=awsMachine machine=openshift-cluster-api/ci-op-kgknj8yp-1d3f3-worker-1-vwwqk
time="2018-10-24T15:08:12Z" level=debug msg="instance exists as \"i-0de7e801e6cb70ca2\"" controller=awsMachine machine=openshift-cluster-api/ci-op-kgknj8yp-1d3f3-worker-1-vwwqk
time="2018-10-24T15:08:12Z" level=debug msg="updating machine" controller=awsMachine machine=openshift-cluster-api/ci-op-kgknj8yp-1d3f3-worker-1-vwwqk
time="2018-10-24T15:08:12Z" level=debug msg="obtaining EC2 client for region" controller=awsMachine machine=openshift-cluster-api/ci-op-kgknj8yp-1d3f3-worker-1-vwwqk region=us-east-1
time="2018-10-24T15:08:12Z" level=debug msg="found 1 instances for machine" controller=awsMachine machine=openshift-cluster-api/ci-op-kgknj8yp-1d3f3-worker-1-vwwqk
time="2018-10-24T15:08:12Z" level=debug msg="instance found" controller=awsMachine instanceID=i-0de7e801e6cb70ca2 machine=openshift-cluster-api/ci-op-kgknj8yp-1d3f3-worker-1-vwwqk
time="2018-10-24T15:08:12Z" level=debug msg="updating status" controller=awsMachine instanceID=i-0de7e801e6cb70ca2 machine=openshift-cluster-api/ci-op-kgknj8yp-1d3f3-worker-1-vwwqk
time="2018-10-24T15:08:12Z" level=debug msg="finished calculating AWS status" controller=awsMachine instanceID=i-0de7e801e6cb70ca2 machine=openshift-cluster-api/ci-op-kgknj8yp-1d3f3-worker-1-vwwqk
time="2018-10-24T15:08:12Z" level=info msg="machine status has changed, updating" controller=awsMachine instanceID=i-0de7e801e6cb70ca2 machine=openshift-cluster-api/ci-op-kgknj8yp-1d3f3-worker-1-vwwqk
```

are pretty opaque without details about what has changed.