### PR TITLE
Import right context package

### DIFF
--- a/cmd/aws-actuator/main.go
+++ b/cmd/aws-actuator/main.go
@@ -22,6 +22,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -49,7 +50,6 @@ import (
 
 	"text/template"
 
-	"golang.org/x/net/context"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )

--- a/pkg/cloud/aws/actuators/machine/actuator.go
+++ b/pkg/cloud/aws/actuators/machine/actuator.go
@@ -17,11 +17,11 @@ limitations under the License.
 package machine
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"

--- a/pkg/cloud/aws/actuators/machine/actuator_test.go
+++ b/pkg/cloud/aws/actuators/machine/actuator_test.go
@@ -1,6 +1,7 @@
 package machine
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -24,7 +25,6 @@ import (
 	mockaws "sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/client/mock"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 
-	"golang.org/x/net/context"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 

--- a/test/integration/create_update_delete_test.go
+++ b/test/integration/create_update_delete_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"path"
@@ -12,7 +13,6 @@ import (
 
 	kubernetesfake "k8s.io/client-go/kubernetes/fake"
 
-	"golang.org/x/net/context"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 


### PR DESCRIPTION
The golang.org/x/net/context.Context is just an alias for context.Context.
Unless necessary let's stick with the definition from the stdlib.
See https://github.com/golang/net/blob/351d144fa1fc0bd934e2408202be0c29f25e35a0/context/go19.go#L15