### PR TITLE
Increase unit test coverage of pkg/cloud/aws/actuators/machine

### DIFF
--- a/pkg/cloud/aws/actuators/machine/awsclient_test.go
+++ b/pkg/cloud/aws/actuators/machine/awsclient_test.go
@@ -1,0 +1,92 @@
+package machine
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	providerconfigv1 "sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1alpha1"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/mock/gomock"
+	mockaws "sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/client/mock"
+)
+
+func TestAwsClient(t *testing.T) {
+	machine, machinePC, err := stubMachine()
+	if err != nil {
+		t.Fatalf("Unable to build test machine manifest: %v", err)
+	}
+
+	machinePC.AMI = providerconfigv1.AWSResourceReference{}
+
+	cases := []struct {
+		name   string
+		output *ec2.DescribeInstancesOutput
+		err    error
+	}{
+		{
+			name: "valid data",
+			output: &ec2.DescribeInstancesOutput{
+				Reservations: []*ec2.Reservation{
+					{
+						Instances: []*ec2.Instance{
+							stubInstance("ami-a9acbbd6", "i-02fcb933c5da7085c"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "valid data with more nil fields",
+			output: &ec2.DescribeInstancesOutput{
+				Reservations: []*ec2.Reservation{
+					{
+						Instances: []*ec2.Instance{
+							{
+								ImageId:    aws.String("ami-a9acbbd6"),
+								InstanceId: aws.String("i-02fcb933c5da7085c"),
+								State: &ec2.InstanceState{
+									Name: aws.String("Running"),
+								},
+								LaunchTime:       aws.Time(time.Now()),
+								PublicDnsName:    aws.String(""),
+								PrivateIpAddress: aws.String(""),
+								Tags: []*ec2.Tag{
+									{
+										Key:   aws.String("key"),
+										Value: aws.String("value"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with error",
+			err:  fmt.Errorf("error"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			mockAWSClient := mockaws.NewMockClient(mockCtrl)
+
+			mockAWSClient.EXPECT().DescribeInstances(gomock.Any()).Return(tc.output, tc.err).AnyTimes()
+
+			acw := NewAwsClientWrapper(mockAWSClient)
+			acw.GetRunningInstances(machine)
+			acw.GetPublicDNSName(machine)
+			acw.GetPrivateIP(machine)
+			acw.GetSecurityGroups(machine)
+			acw.GetIAMRole(machine)
+			acw.GetTags(machine)
+			acw.GetSubnet(machine)
+			acw.GetAvailabilityZone(machine)
+		})
+	}
+}

--- a/pkg/cloud/aws/actuators/machine/instaces_test.go
+++ b/pkg/cloud/aws/actuators/machine/instaces_test.go
@@ -1,12 +1,17 @@
 package machine
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	providerconfigv1 "sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1alpha1"
+
+	"github.com/golang/mock/gomock"
+	mockaws "sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/client/mock"
 )
 
 func TestRemoveDuplicatedTags(t *testing.T) {
@@ -83,4 +88,273 @@ func TestBuildEC2Filters(t *testing.T) {
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("failed to buildEC2Filters. Expected: %+v, got: %+v", expected, got)
 	}
+}
+
+func TestRemoveStoppedMachine(t *testing.T) {
+	machine, _, err := stubMachine()
+	if err != nil {
+		t.Errorf("Unable to build test machine manifest: %v", err)
+	}
+
+	cases := []struct {
+		name   string
+		output *ec2.DescribeInstancesOutput
+		err    error
+	}{
+		{
+			name:   "DescribeInstances with error",
+			output: &ec2.DescribeInstancesOutput{},
+			// any non-nil error will do
+			err: fmt.Errorf("error describing instances"),
+		},
+		{
+			name: "No instances to stop",
+			output: &ec2.DescribeInstancesOutput{
+				Reservations: []*ec2.Reservation{
+					{
+						Instances: []*ec2.Instance{},
+					},
+				},
+			},
+		},
+		{
+			name: "One instance to stop",
+			output: &ec2.DescribeInstancesOutput{
+				Reservations: []*ec2.Reservation{
+					{
+						Instances: []*ec2.Instance{
+							stubInstance("ami-a9acbbd6", "i-02fcb933c5da7085c"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Two instances to stop",
+			output: &ec2.DescribeInstancesOutput{
+				Reservations: []*ec2.Reservation{
+					{
+						Instances: []*ec2.Instance{
+							stubInstance("ami-a9acbbd6", "i-02fcb933c5da7085c"),
+							stubInstance("ami-a9acbbd7", "i-02fcb933c5da7085d"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			mockAWSClient := mockaws.NewMockClient(mockCtrl)
+			// Not here to check how many times all the mocked methods get called.
+			// Rather to provide fake outputs to get through all possible execution paths.
+			mockAWSClient.EXPECT().DescribeInstances(gomock.Any()).Return(tc.output, tc.err).AnyTimes()
+			mockAWSClient.EXPECT().TerminateInstances(gomock.Any()).AnyTimes()
+			removeStoppedMachine(machine, mockAWSClient)
+		})
+	}
+}
+
+func TestRunningInstace(t *testing.T) {
+	machine, _, err := stubMachine()
+	if err != nil {
+		t.Fatalf("Unable to build test machine manifest: %v", err)
+	}
+
+	mockCtrl := gomock.NewController(t)
+	mockAWSClient := mockaws.NewMockClient(mockCtrl)
+
+	// Error describing instances
+	mockAWSClient.EXPECT().DescribeInstances(gomock.Any()).Return(&ec2.DescribeInstancesOutput{
+		Reservations: []*ec2.Reservation{
+			{
+				Instances: []*ec2.Instance{
+					{
+						ImageId:    aws.String("ami-a9acbbd6"),
+						InstanceId: aws.String("i-02fcb933c5da7085c"),
+						State: &ec2.InstanceState{
+							Name: aws.String("Running"),
+						},
+						LaunchTime: aws.Time(time.Now()),
+					},
+				},
+			},
+		},
+	}, nil).AnyTimes()
+	getRunningInstance(machine, mockAWSClient)
+}
+
+func TestLaunchInstance(t *testing.T) {
+	machine, _, err := stubMachine()
+	if err != nil {
+		t.Fatalf("Unable to build test machine manifest: %v", err)
+	}
+
+	cases := []struct {
+		name                string
+		providerConfig      *providerconfigv1.AWSMachineProviderConfig
+		securityGroupOutput *ec2.DescribeSecurityGroupsOutput
+		securityGroupErr    error
+		subnetOutput        *ec2.DescribeSubnetsOutput
+		subnetErr           error
+		imageOutput         *ec2.DescribeImagesOutput
+		imageErr            error
+	}{
+		{
+			name: "Security groups with filters",
+			providerConfig: stubPCSecurityGroups(
+				[]providerconfigv1.AWSResourceReference{
+					{
+						Filters: []providerconfigv1.Filter{},
+					},
+				},
+			),
+			securityGroupOutput: &ec2.DescribeSecurityGroupsOutput{
+				SecurityGroups: []*ec2.SecurityGroup{
+					{
+						GroupId: aws.String("groupID"),
+					},
+				},
+			},
+		},
+		{
+			name: "Security groups with filters with error",
+			providerConfig: stubPCSecurityGroups(
+				[]providerconfigv1.AWSResourceReference{
+					{
+						Filters: []providerconfigv1.Filter{},
+					},
+				},
+			),
+			securityGroupErr: fmt.Errorf("error"),
+		},
+		{
+			name: "No security group",
+			providerConfig: stubPCSecurityGroups(
+				[]providerconfigv1.AWSResourceReference{
+					{
+						Filters: []providerconfigv1.Filter{},
+					},
+				},
+			),
+			securityGroupOutput: &ec2.DescribeSecurityGroupsOutput{
+				SecurityGroups: []*ec2.SecurityGroup{},
+			},
+		},
+		{
+			name: "Subnet with filters",
+			providerConfig: stubPCSubnet(providerconfigv1.AWSResourceReference{
+				Filters: []providerconfigv1.Filter{},
+			}),
+			subnetOutput: &ec2.DescribeSubnetsOutput{
+				Subnets: []*ec2.Subnet{
+					{
+						SubnetId: aws.String("subnetID"),
+					},
+				},
+			},
+		},
+		{
+			name: "Subnet with filters with error",
+			providerConfig: stubPCSubnet(providerconfigv1.AWSResourceReference{
+				Filters: []providerconfigv1.Filter{},
+			}),
+			subnetErr: fmt.Errorf("error"),
+		},
+		{
+			name: "AMI with filters",
+			providerConfig: stubPCAMI(providerconfigv1.AWSResourceReference{
+				Filters: []providerconfigv1.Filter{},
+			}),
+			imageOutput: &ec2.DescribeImagesOutput{
+				Images: []*ec2.Image{
+					{
+						CreationDate: aws.String(time.RFC3339),
+						ImageId:      aws.String("ami-1111"),
+					},
+				},
+			},
+		},
+		{
+			name: "AMI with filters with error",
+			providerConfig: stubPCAMI(providerconfigv1.AWSResourceReference{
+				Filters: []providerconfigv1.Filter{},
+			}),
+			imageErr: fmt.Errorf("error"),
+		},
+		{
+			name: "AMI with filters with no image",
+			providerConfig: stubPCAMI(providerconfigv1.AWSResourceReference{
+				Filters: []providerconfigv1.Filter{
+					{
+						Name:   "image_stage",
+						Values: []string{"base"},
+					},
+				},
+			}),
+			imageOutput: &ec2.DescribeImagesOutput{
+				Images: []*ec2.Image{},
+			},
+		},
+		{
+			name: "AMI with filters with two images",
+			providerConfig: stubPCAMI(providerconfigv1.AWSResourceReference{
+				Filters: []providerconfigv1.Filter{
+					{
+						Name:   "image_stage",
+						Values: []string{"base"},
+					},
+				},
+			}),
+			imageOutput: &ec2.DescribeImagesOutput{
+				Images: []*ec2.Image{
+					{
+						CreationDate: aws.String("2006-01-02T15:04:05Z"),
+						ImageId:      aws.String("ami-1111"),
+					},
+					{
+						CreationDate: aws.String("2006-01-02T15:04:05Z"),
+						ImageId:      aws.String("ami-2222"),
+					},
+				},
+			},
+		},
+		{
+			name:           "AMI not specified",
+			providerConfig: stubPCAMI(providerconfigv1.AWSResourceReference{}),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			mockAWSClient := mockaws.NewMockClient(mockCtrl)
+
+			mockAWSClient.EXPECT().DescribeSecurityGroups(gomock.Any()).Return(tc.securityGroupOutput, tc.securityGroupErr).AnyTimes()
+			mockAWSClient.EXPECT().DescribeSubnets(gomock.Any()).Return(tc.subnetOutput, tc.subnetErr).AnyTimes()
+			mockAWSClient.EXPECT().DescribeImages(gomock.Any()).Return(tc.imageOutput, tc.imageErr).AnyTimes()
+			mockAWSClient.EXPECT().RunInstances(gomock.Any())
+
+			launchInstance(machine, tc.providerConfig, nil, mockAWSClient)
+		})
+	}
+}
+
+func TestSortInstances(t *testing.T) {
+	instances := []*ec2.Instance{
+		{
+			LaunchTime: aws.Time(time.Now()),
+		},
+		{
+			LaunchTime: nil,
+		},
+		{
+			LaunchTime: nil,
+		},
+		{
+			LaunchTime: aws.Time(time.Now()),
+		},
+	}
+	sortInstances(instances)
 }

--- a/pkg/cloud/aws/actuators/machine/loadbalancers_test.go
+++ b/pkg/cloud/aws/actuators/machine/loadbalancers_test.go
@@ -1,0 +1,48 @@
+package machine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	mockaws "sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/client/mock"
+)
+
+func TestRegisterWithNetworkLoadBalancers(t *testing.T) {
+	cases := []struct {
+		name              string
+		lbErr             error
+		targetGroupErr    error
+		registerTargetErr error
+		err               error
+	}{
+		{
+			name: "No error",
+		},
+		{
+			name:  "With describe lb error",
+			lbErr: fmt.Errorf("error"),
+		},
+		{
+			name:           "With target group error",
+			targetGroupErr: fmt.Errorf("error"),
+		},
+		{
+			name:              "With register target error",
+			registerTargetErr: fmt.Errorf("error"),
+		},
+	}
+
+	instance := stubInstance("ami-a9acbbd6", "i-02fcb933c5da7085c")
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			mockAWSClient := mockaws.NewMockClient(mockCtrl)
+			mockAWSClient.EXPECT().ELBv2DescribeLoadBalancers(gomock.Any()).Return(stubDescribeLoadBalancersOutput(), tc.lbErr)
+			mockAWSClient.EXPECT().ELBv2DescribeTargetGroups(gomock.Any()).Return(stubDescribeTargetGroupsOutput(), tc.targetGroupErr).AnyTimes()
+			mockAWSClient.EXPECT().ELBv2RegisterTargets(gomock.Any()).Return(nil, tc.registerTargetErr).AnyTimes()
+			registerWithNetworkLoadBalancers(mockAWSClient, []string{"name1", "name2"}, instance)
+		})
+	}
+}

--- a/pkg/cloud/aws/actuators/machine/stubs.go
+++ b/pkg/cloud/aws/actuators/machine/stubs.go
@@ -6,9 +6,12 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+
 	apiv1 "k8s.io/api/core/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	providerconfigv1 "sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1alpha1"
 	"sigs.k8s.io/cluster-api-provider-aws/test/utils"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
@@ -198,4 +201,30 @@ func stubPCAMI(ami providerconfigv1.AWSResourceReference) *providerconfigv1.AWSM
 	pc := stubProviderConfig()
 	pc.AMI = ami
 	return pc
+}
+
+func stubDescribeLoadBalancersOutput() *elbv2.DescribeLoadBalancersOutput {
+	return &elbv2.DescribeLoadBalancersOutput{
+		LoadBalancers: []*elbv2.LoadBalancer{
+			{
+				LoadBalancerName: aws.String("lbname"),
+				LoadBalancerArn:  aws.String("lbarn"),
+			},
+		},
+	}
+}
+
+func stubDescribeTargetGroupsOutput() *elbv2.DescribeTargetGroupsOutput {
+	return &elbv2.DescribeTargetGroupsOutput{
+		TargetGroups: []*elbv2.TargetGroup{
+			{
+				TargetType:     aws.String(elbv2.TargetTypeEnumInstance),
+				TargetGroupArn: aws.String("arn1"),
+			},
+			{
+				TargetType:     aws.String(elbv2.TargetTypeEnumIp),
+				TargetGroupArn: aws.String("arn2"),
+			},
+		},
+	}
 }

--- a/pkg/cloud/aws/actuators/machine/stubs.go
+++ b/pkg/cloud/aws/actuators/machine/stubs.go
@@ -1,0 +1,201 @@
+package machine
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	providerconfigv1 "sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1alpha1"
+	"sigs.k8s.io/cluster-api-provider-aws/test/utils"
+	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+)
+
+const (
+	defaultNamespace         = "default"
+	defaultAvailabilityZone  = "us-east-1a"
+	region                   = "us-east-1"
+	awsCredentialsSecretName = "aws-credentials-secret"
+	userDataSecretName       = "aws-actuator-user-data-secret"
+
+	keyName   = "aws-actuator-key-name"
+	clusterID = "aws-actuator-cluster"
+)
+
+const userDataBlob = `#cloud-config
+write_files:
+- path: /root/node_bootstrap/node_settings.yaml
+  owner: 'root:root'
+  permissions: '0640'
+  content: |
+    node_config_name: node-config-master
+runcmd:
+- [ cat, /root/node_bootstrap/node_settings.yaml]
+`
+
+func stubProviderConfig() *providerconfigv1.AWSMachineProviderConfig {
+	return &providerconfigv1.AWSMachineProviderConfig{
+		AMI: providerconfigv1.AWSResourceReference{
+			ID: aws.String("ami-a9acbbd6"),
+		},
+		CredentialsSecret: &corev1.LocalObjectReference{
+			Name: awsCredentialsSecretName,
+		},
+		InstanceType: "m4.xlarge",
+		Placement: providerconfigv1.Placement{
+			Region:           region,
+			AvailabilityZone: defaultAvailabilityZone,
+		},
+		Subnet: providerconfigv1.AWSResourceReference{
+			ID: aws.String("subnet-0e56b13a64ff8a941"),
+		},
+		IAMInstanceProfile: &providerconfigv1.AWSResourceReference{
+			ID: aws.String("openshift_master_launch_instances"),
+		},
+		KeyName: aws.String(keyName),
+		UserDataSecret: &corev1.LocalObjectReference{
+			Name: userDataSecretName,
+		},
+		Tags: []providerconfigv1.TagSpecification{
+			{Name: "openshift-node-group-config", Value: "node-config-master"},
+			{Name: "host-type", Value: "master"},
+			{Name: "sub-host-type", Value: "default"},
+		},
+		SecurityGroups: []providerconfigv1.AWSResourceReference{
+			{ID: aws.String("sg-00868b02fbe29de17")},
+			{ID: aws.String("sg-0a4658991dc5eb40a")},
+			{ID: aws.String("sg-009a70e28fa4ba84e")},
+			{ID: aws.String("sg-07323d56fb932c84c")},
+			{ID: aws.String("sg-08b1ffd32874d59a2")},
+		},
+		PublicIP: aws.Bool(true),
+		LoadBalancers: []providerconfigv1.LoadBalancerReference{
+			{
+				Name: "cluster-con",
+				Type: providerconfigv1.ClassicLoadBalancerType,
+			},
+			{
+				Name: "cluster-ext",
+				Type: providerconfigv1.ClassicLoadBalancerType,
+			},
+			{
+				Name: "cluster-int",
+				Type: providerconfigv1.ClassicLoadBalancerType,
+			},
+		},
+	}
+}
+
+func stubMachine() (*clusterv1.Machine, *providerconfigv1.AWSMachineProviderConfig, error) {
+	machinePc := stubProviderConfig()
+
+	codec, err := providerconfigv1.NewCodec()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed creating codec: %v", err)
+	}
+	config, err := codec.EncodeProviderConfig(machinePc)
+	if err != nil {
+		return nil, nil, fmt.Errorf("encodeToProviderConfig failed: %v", err)
+	}
+
+	machine := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "aws-actuator-testing-machine",
+			Namespace: defaultNamespace,
+			Labels: map[string]string{
+				providerconfigv1.ClusterIDLabel:   clusterID,
+				providerconfigv1.MachineRoleLabel: "infra",
+				providerconfigv1.MachineTypeLabel: "master",
+			},
+		},
+
+		Spec: clusterv1.MachineSpec{
+			ProviderConfig: *config,
+		},
+	}
+
+	return machine, machinePc, nil
+}
+
+func stubMachineAPIResources() (*clusterv1.Machine, *clusterv1.Cluster, *apiv1.Secret, *apiv1.Secret, error) {
+	awsCredentialsSecret := utils.GenerateAwsCredentialsSecretFromEnv(awsCredentialsSecretName, defaultNamespace)
+
+	userDataSecret := &apiv1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      userDataSecretName,
+			Namespace: defaultNamespace,
+		},
+		Data: map[string][]byte{
+			userDataSecretKey: []byte(userDataBlob),
+		},
+	}
+
+	machine, _, err := stubMachine()
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	cluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterID,
+			Namespace: defaultNamespace,
+		},
+	}
+
+	return machine, cluster, awsCredentialsSecret, userDataSecret, nil
+}
+
+func stubInstance(imageID, instanceID string) *ec2.Instance {
+	return &ec2.Instance{
+		ImageId:    aws.String(imageID),
+		InstanceId: aws.String(instanceID),
+		State: &ec2.InstanceState{
+			Name: aws.String("Running"),
+			Code: aws.Int64(16),
+		},
+		LaunchTime:       aws.Time(time.Now()),
+		PublicDnsName:    aws.String("publicDNS"),
+		PrivateDnsName:   aws.String("privateDNS"),
+		PublicIpAddress:  aws.String("1.1.1.1"),
+		PrivateIpAddress: aws.String("1.1.1.1"),
+		Tags: []*ec2.Tag{
+			{
+				Key:   aws.String("key"),
+				Value: aws.String("value"),
+			},
+		},
+		IamInstanceProfile: &ec2.IamInstanceProfile{
+			Id: aws.String("profile"),
+		},
+		SubnetId: aws.String("subnetID"),
+		Placement: &ec2.Placement{
+			AvailabilityZone: aws.String("us-east-1a"),
+		},
+		SecurityGroups: []*ec2.GroupIdentifier{
+			{
+				GroupName: aws.String("groupName"),
+			},
+		},
+	}
+}
+
+func stubPCSecurityGroups(groups []providerconfigv1.AWSResourceReference) *providerconfigv1.AWSMachineProviderConfig {
+	pc := stubProviderConfig()
+	pc.SecurityGroups = groups
+	return pc
+}
+
+func stubPCSubnet(subnet providerconfigv1.AWSResourceReference) *providerconfigv1.AWSMachineProviderConfig {
+	pc := stubProviderConfig()
+	pc.Subnet = subnet
+	return pc
+}
+
+func stubPCAMI(ami providerconfigv1.AWSResourceReference) *providerconfigv1.AWSMachineProviderConfig {
+	pc := stubProviderConfig()
+	pc.AMI = ami
+	return pc
+}

--- a/pkg/cloud/aws/actuators/machine/stubs.go
+++ b/pkg/cloud/aws/actuators/machine/stubs.go
@@ -88,6 +88,10 @@ func stubProviderConfig() *providerconfigv1.AWSMachineProviderConfig {
 				Name: "cluster-int",
 				Type: providerconfigv1.ClassicLoadBalancerType,
 			},
+			{
+				Name: "cluster-net-lb",
+				Type: providerconfigv1.NetworkLoadBalancerType,
+			},
 		},
 	}
 }

--- a/pkg/cloud/aws/actuators/machine/stubs.go
+++ b/pkg/cloud/aws/actuators/machine/stubs.go
@@ -228,3 +228,39 @@ func stubDescribeTargetGroupsOutput() *elbv2.DescribeTargetGroupsOutput {
 		},
 	}
 }
+
+func stubReservation(imageID, instanceID string) *ec2.Reservation {
+	return &ec2.Reservation{
+		Instances: []*ec2.Instance{
+			{
+				ImageId:    aws.String(imageID),
+				InstanceId: aws.String(instanceID),
+				State: &ec2.InstanceState{
+					Name: aws.String("Running"),
+					Code: aws.Int64(16),
+				},
+				LaunchTime: aws.Time(time.Now()),
+			},
+		},
+	}
+}
+
+func stubDescribeInstancesOutput(imageID, instanceID string) *ec2.DescribeInstancesOutput {
+	return &ec2.DescribeInstancesOutput{
+		Reservations: []*ec2.Reservation{
+			{
+				Instances: []*ec2.Instance{
+					{
+						ImageId:    aws.String(imageID),
+						InstanceId: aws.String(instanceID),
+						State: &ec2.InstanceState{
+							Name: aws.String("Running"),
+							Code: aws.Int64(16),
+						},
+						LaunchTime: aws.Time(time.Now()),
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/cloud/aws/actuators/machine/utils.go
+++ b/pkg/cloud/aws/actuators/machine/utils.go
@@ -178,25 +178,6 @@ func IsMaster(machine *clusterv1.Machine) bool {
 	return false
 }
 
-// IsInfra returns true if the machine is part of a cluster's infra plane
-func IsInfra(machine *clusterv1.Machine) bool {
-	if machineRole, exists := machine.ObjectMeta.Labels[providerconfigv1.MachineRoleLabel]; exists && machineRole == "infra" {
-		return true
-	}
-	return false
-}
-
-// StringPtrsEqual safely returns true if the value for each string pointer is equal, or both are nil.
-func StringPtrsEqual(s1, s2 *string) bool {
-	if s1 == s2 {
-		return true
-	}
-	if s1 == nil || s2 == nil {
-		return false
-	}
-	return *s1 == *s2
-}
-
 // UpdateConditionCheck tests whether a condition should be updated from the
 // old condition to the new condition. Returns true if the condition should
 // be updated.


### PR DESCRIPTION
Increase unit test coverage before:
- sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/actuators/machine/actuator.go (62.1%)
- sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/actuators/machine/awsclient.go (0.0%)
- sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/actuators/machine/instances.go (52.9%)
- sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/actuators/machine/loadbalancers.go (18.4%)
- sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/actuators/machine/utils.go (53.9%)

Increase unit test coverage after:
- sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/actuators/machine/actuator.go (91.6%)
- sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/actuators/machine/awsclient.go (100.0%)
- sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/actuators/machine/instances.go (91.2%)
- sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/actuators/machine/loadbalancers.go (91.8%)
- sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/actuators/machine/stubs.go (100.0%)
- sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/actuators/machine/utils.go (76.5%)

Goal:
- get coverage of each package above 90%

Current:
```sh
$ go test -race -cover ./pkg/cloud/aws/actuators/machine...
ok  	sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/actuators/machine	1.139s	coverage: 90.1% of statements
```