### PR TITLE
crd/machinesets: add additional printer columns

### DIFF
--- a/config/crds/machineset.crd.yaml
+++ b/config/crds/machineset.crd.yaml
@@ -94,6 +94,22 @@ spec:
           - replicas
           type: object
   version: v1alpha1
+  additionalPrinterColumns:
+  - JSONPath: .spec.replicas
+    description: Desired Replicas
+    name: Desired
+    type: integer
+  - JSONPath: .status.replicas
+    description: Current Replicas
+    name: Current
+    type: integer
+  - JSONPath: .status.readyReplicas
+    description: Ready Replicas
+    name: Ready
+    type: integer
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
This adds 'desired', 'current' and 'ready' replica counts as default
columns for `kubectl get machinesets`. It also adds 'age'. This output
mirrors the output you get from `kubectl get replicasets`.