### PR TITLE
config/crds/machine: add additional printer columns

### DIFF
--- a/config/crds/machine.crd.yaml
+++ b/config/crds/machine.crd.yaml
@@ -83,6 +83,18 @@ spec:
               type: object
           type: object
   version: v1alpha1
+  additionalPrinterColumns:
+  - JSONPath: .spec.providerConfig.value.instanceType
+    description: Instance Type
+    name: Instance Type
+    type: string
+  - JSONPath: .spec.providerConfig.value.placement.availabilityZone
+    description: Zone
+    name: Zone
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
Adds additional printer columns that display AWS-specific instance
properties: 'instance type', 'zone' (which covers the region) in
addition to machine 'age'.