### PR TITLE
Remove kubeclient in favor of runtime controller client

### DIFF
--- a/cmd/aws-actuator/main.go
+++ b/cmd/aws-actuator/main.go
@@ -44,7 +44,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	kubernetesfake "k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"k8s.io/client-go/kubernetes/scheme"
 
@@ -319,8 +319,8 @@ func bootstrapCommand() *cobra.Command {
 			}
 
 			objList := []runtime.Object{awsCredentialsSecret}
-			fakeKubeClient := kubernetesfake.NewSimpleClientset(objList...)
-			awsClient, err := awsclient.NewClient(fakeKubeClient, awsCredentialsSecret.Name, awsCredentialsSecret.Namespace, region)
+			fakeClient := fake.NewFakeClient(objList...)
+			awsClient, err := awsclient.NewClient(fakeClient, awsCredentialsSecret.Name, awsCredentialsSecret.Namespace, region)
 			if err != nil {
 				glog.Errorf("Unable to create aws client: %v", err)
 				return err

--- a/cmd/aws-actuator/utils/utils.go
+++ b/cmd/aws-actuator/utils/utils.go
@@ -8,7 +8,6 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	kubernetesfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1alpha1"
 	machineactuator "sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/actuators/machine"
@@ -17,15 +16,14 @@ import (
 
 // CreateActuator creates actuator with fake clientsets
 func CreateActuator(machine *clusterv1.Machine, awsCredentials *apiv1.Secret, userData *apiv1.Secret) *machineactuator.Actuator {
-	objList := []runtime.Object{}
+	objList := []runtime.Object{machine}
 	if awsCredentials != nil {
 		objList = append(objList, awsCredentials)
 	}
 	if userData != nil {
 		objList = append(objList, userData)
 	}
-	fakeClient := fake.NewFakeClient(machine)
-	fakeKubeClient := kubernetesfake.NewSimpleClientset(objList...)
+	fakeClient := fake.NewFakeClient(objList...)
 
 	codec, err := v1alpha1.NewCodec()
 	if err != nil {
@@ -34,7 +32,6 @@ func CreateActuator(machine *clusterv1.Machine, awsCredentials *apiv1.Secret, us
 
 	params := machineactuator.ActuatorParams{
 		Client:           fakeClient,
-		KubeClient:       fakeKubeClient,
 		AwsClientBuilder: awsclient.NewClient,
 		Codec:            codec,
 		// use empty recorder dropping any event recorded

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -17,7 +17,6 @@ import (
 	"flag"
 
 	"github.com/golang/glog"
-	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/apis"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1alpha1"
@@ -69,13 +68,6 @@ func main() {
 }
 
 func initActuator(mgr manager.Manager) {
-	config := mgr.GetConfig()
-
-	kubeClient, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		glog.Fatalf("Could not create kubernetes client to talk to the apiserver: %v", err)
-	}
-
 	codec, err := v1alpha1.NewCodec()
 	if err != nil {
 		glog.Fatal(err)
@@ -83,7 +75,6 @@ func initActuator(mgr manager.Manager) {
 
 	params := machineactuator.ActuatorParams{
 		Client:           mgr.GetClient(),
-		KubeClient:       kubeClient,
 		AwsClientBuilder: awsclient.NewClient,
 		Codec:            codec,
 		EventRecorder:    mgr.GetRecorder("aws-controller"),

--- a/test/integration/create_update_delete_test.go
+++ b/test/integration/create_update_delete_test.go
@@ -11,8 +11,6 @@ import (
 	//"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	kubernetesfake "k8s.io/client-go/kubernetes/fake"
-
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -104,12 +102,10 @@ func TestCreateAndDeleteMachine(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fakeKubeClient := kubernetesfake.NewSimpleClientset(awsCredentialsSecret, userDataSecret)
-	fakeClient := fake.NewFakeClient(machine)
+	fakeClient := fake.NewFakeClient(machine, awsCredentialsSecret, userDataSecret)
 
 	params := machineactuator.ActuatorParams{
 		Client:           fakeClient,
-		KubeClient:       fakeKubeClient,
 		AwsClientBuilder: awsclient.NewClient,
 	}
 

--- a/test/machines/machines_test.go
+++ b/test/machines/machines_test.go
@@ -2,6 +2,7 @@ package machines
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/labels"
@@ -120,7 +121,7 @@ var _ = framework.SigKubeDescribe("Machines", func() {
 			f.CreateClusterAndWait(cluster)
 
 			var err error
-			awsClient, err = awsclient.NewClient(f.KubeClient, awsCredSecret.Name, awsCredSecret.Namespace, region)
+			awsClient, err = awsclient.NewClientFromKeys(os.Getenv("AWS_ACCESS_KEY_ID"), os.Getenv("AWS_SECRET_ACCESS_KEY"), region)
 			Expect(err).NotTo(HaveOccurred())
 			acw = machineutils.NewAwsClientWrapper(awsClient)
 


### PR DESCRIPTION
Built on top of https://github.com/openshift/cluster-api-provider-aws/pull/127

This is the last occurrence where we use Kubernetes client (besides e2e framework).