### PR TITLE
Fix make test-e2e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ k8s-e2e: ## Run k8s specific e2e test
 		-args -v 5 -logtostderr true
 
 .PHONY: test-e2e
-validate-e2e: ## Run e2e validation/gating test
+test-e2e: ## Run e2e validation/gating test
 	go run ./test/e2e/*.go -alsologtostderr
 
 .PHONY: lint


### PR DESCRIPTION
During renaming of validate-e2e to test-e2e we forget
to rename the label itself. Thus, the test-e2e was not
doing anything at all.