### PR TITLE
Remove providerconfig

### DIFF
--- a/cmd/aws-actuator/main.go
+++ b/cmd/aws-actuator/main.go
@@ -270,12 +270,12 @@ func bootstrapCommand() *cobra.Command {
 				return err
 			}
 
-			masterMachineProviderConfig, err := testutils.MasterMachineProviderConfig(awsCredentialsSecret.Name, masterUserDataSecret.Name, testCluster.Name)
+			masterMachineProviderSpec, err := testutils.MasterMachineProviderSpec(awsCredentialsSecret.Name, masterUserDataSecret.Name, testCluster.Name)
 			if err != nil {
 				return err
 			}
 
-			masterMachine := manifests.MasterMachine(testCluster.Name, testCluster.Namespace, masterMachineProviderConfig)
+			masterMachine := manifests.MasterMachine(testCluster.Name, testCluster.Namespace, masterMachineProviderSpec)
 
 			glog.Infof("Creating master machine")
 
@@ -382,11 +382,11 @@ func bootstrapCommand() *cobra.Command {
 			}
 
 			createSecretAndWait(clusterFramework, workerUserDataSecret)
-			workerMachineSetProviderConfig, err := testutils.WorkerMachineSetProviderConfig(awsCredentialsSecret.Name, workerUserDataSecret.Name, testCluster.Name)
+			workerMachineSetProviderSpec, err := testutils.WorkerMachineSetProviderSpec(awsCredentialsSecret.Name, workerUserDataSecret.Name, testCluster.Name)
 			if err != nil {
 				return err
 			}
-			workerMachineSet := manifests.WorkerMachineSet(testCluster.Name, testCluster.Namespace, workerMachineSetProviderConfig)
+			workerMachineSet := manifests.WorkerMachineSet(testCluster.Name, testCluster.Namespace, workerMachineSetProviderSpec)
 			clusterFramework.CreateMachineSetAndWait(workerMachineSet, acw)
 
 			return nil

--- a/config/crds/cluster.crd.yaml
+++ b/config/crds/cluster.crd.yaml
@@ -51,7 +51,7 @@ spec:
               - pods
               - serviceDomain
               type: object
-            providerConfig:
+            providerSpec:
               properties:
                 value:
                   type: object

--- a/config/crds/machine.crd.yaml
+++ b/config/crds/machine.crd.yaml
@@ -28,7 +28,7 @@ spec:
               type: object
             metadata:
               type: object
-            providerConfig:
+            providerSpec:
               properties:
                 value:
                   type: object
@@ -49,7 +49,7 @@ spec:
               - kubelet
               type: object
           required:
-          - providerConfig
+          - providerSpec
           type: object
         status:
           properties:

--- a/config/crds/machinedeployment.crd.yaml
+++ b/config/crds/machinedeployment.crd.yaml
@@ -62,7 +62,7 @@ spec:
                       type: object
                     metadata:
                       type: object
-                    providerConfig:
+                    providerSpec:
                       properties:
                         value:
                           type: object
@@ -83,7 +83,7 @@ spec:
                       - kubelet
                       type: object
                   required:
-                  - providerConfig
+                  - providerSpec
                   type: object
               type: object
           required:

--- a/config/crds/machineset.crd.yaml
+++ b/config/crds/machineset.crd.yaml
@@ -42,7 +42,7 @@ spec:
                       type: object
                     metadata:
                       type: object
-                    providerConfig:
+                    providerSpec:
                       properties:
                         value:
                           type: object
@@ -63,7 +63,7 @@ spec:
                       - kubelet
                       type: object
                   required:
-                  - providerConfig
+                  - providerSpec
                   type: object
               type: object
           required:

--- a/examples/machine-set.yaml
+++ b/examples/machine-set.yaml
@@ -22,7 +22,7 @@ spec:
         sigs.k8s.io/cluster-api-machine-role: infra
         sigs.k8s.io/cluster-api-machine-type: master
     spec:
-      providerConfig:
+      providerSpec:
         value:
           apiVersion: awsproviderconfig.k8s.io/v1alpha1
           kind: AWSMachineProviderConfig

--- a/examples/machine-with-filters.yaml
+++ b/examples/machine-with-filters.yaml
@@ -10,7 +10,7 @@ metadata:
     sigs.k8s.io/cluster-api-machine-role: compute
     sigs.k8s.io/cluster-api-machine-type: worker
 spec:
-  providerConfig:
+  providerSpec:
     value:
       apiVersion: awsproviderconfig.k8s.io/v1alpha1
       kind: AWSMachineProviderConfig

--- a/examples/machine-with-user-data.yaml
+++ b/examples/machine-with-user-data.yaml
@@ -10,7 +10,7 @@ metadata:
     sigs.k8s.io/cluster-api-machine-role: infra
     sigs.k8s.io/cluster-api-machine-type: master
 spec:
-  providerConfig:
+  providerSpec:
     value:
       apiVersion: awsproviderconfig.k8s.io/v1alpha1
       kind: AWSMachineProviderConfig

--- a/examples/machine.yaml
+++ b/examples/machine.yaml
@@ -10,7 +10,7 @@ metadata:
     sigs.k8s.io/cluster-api-machine-role: infra
     sigs.k8s.io/cluster-api-machine-type: master
 spec:
-  providerConfig:
+  providerSpec:
     value:
       apiVersion: awsproviderconfig.k8s.io/v1alpha1
       kind: AWSMachineProviderConfig

--- a/examples/master-machine.yaml
+++ b/examples/master-machine.yaml
@@ -10,7 +10,7 @@ metadata:
     sigs.k8s.io/cluster-api-machine-role: infra
     sigs.k8s.io/cluster-api-machine-type: master
 spec:
-  providerConfig:
+  providerSpec:
     value:
       apiVersion: awsproviderconfig.k8s.io/v1alpha1
       kind: AWSMachineProviderConfig

--- a/examples/worker-machine.yaml
+++ b/examples/worker-machine.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     sigs.k8s.io/cluster-api-cluster: tb-asg-35
 spec:
-  providerConfig:
+  providerSpec:
     value:
       apiVersion: awsproviderconfig.k8s.io/v1alpha1
       kind: AWSMachineProviderConfig

--- a/examples/worker-machineset.yaml
+++ b/examples/worker-machineset.yaml
@@ -21,7 +21,7 @@ spec:
       metadata:
         labels:
           node-role.kubernetes.io/compute: ""
-      providerConfig:
+      providerSpec:
         value:
           apiVersion: awsproviderconfig.k8s.io/v1alpha1
           kind: AWSMachineProviderConfig

--- a/pkg/actuators/machine/actuator_test.go
+++ b/pkg/actuators/machine/actuator_test.go
@@ -599,7 +599,7 @@ func TestAvailabiltyZone(t *testing.T) {
 			}
 
 			machinePc := &providerconfigv1.AWSMachineProviderConfig{}
-			if err = codec.DecodeProviderConfig(&machine.Spec.ProviderSpec, machinePc); err != nil {
+			if err = codec.DecodeProviderSpec(&machine.Spec.ProviderSpec, machinePc); err != nil {
 				t.Fatal(err)
 			}
 
@@ -613,7 +613,7 @@ func TestAvailabiltyZone(t *testing.T) {
 				machinePc.Subnet.ID = aws.String(tc.subnet)
 			}
 
-			config, err := codec.EncodeProviderConfig(machinePc)
+			config, err := codec.EncodeProviderSpec(machinePc)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/actuators/machine/stubs.go
+++ b/pkg/actuators/machine/stubs.go
@@ -103,9 +103,9 @@ func stubMachine() (*clusterv1.Machine, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed creating codec: %v", err)
 	}
-	config, err := codec.EncodeProviderConfig(machinePc)
+	providerSpec, err := codec.EncodeProviderSpec(machinePc)
 	if err != nil {
-		return nil, fmt.Errorf("codec.EncodeProviderConfig failed: %v", err)
+		return nil, fmt.Errorf("codec.EncodeProviderSpec failed: %v", err)
 	}
 
 	machine := &clusterv1.Machine{
@@ -120,7 +120,7 @@ func stubMachine() (*clusterv1.Machine, error) {
 		},
 
 		Spec: clusterv1.MachineSpec{
-			ProviderSpec: *config,
+			ProviderSpec: *providerSpec,
 		},
 	}
 

--- a/pkg/actuators/machine/utils.go
+++ b/pkg/actuators/machine/utils.go
@@ -141,18 +141,9 @@ func terminateInstances(client awsclient.Client, instances []*ec2.Instance) erro
 func providerConfigFromMachine(client client.Client, machine *clusterv1.Machine, codec *providerconfigv1.AWSProviderConfigCodec) (*providerconfigv1.AWSMachineProviderConfig, error) {
 	var providerSpecRawExtention runtime.RawExtension
 
-	// TODO(jchaloup): Remove providerConfig once all consumers migrate to providerSpec
-	providerSpec := machine.Spec.ProviderConfig
-	// providerSpec has higher priority over providerConfig
-	if machine.Spec.ProviderSpec.Value != nil || machine.Spec.ProviderSpec.ValueFrom != nil {
-		providerSpec = machine.Spec.ProviderSpec
-		glog.Infof("Falling to default providerSpec\n")
-	} else {
-		glog.Infof("Falling to providerConfig\n")
-	}
-
+	providerSpec := machine.Spec.ProviderSpec
 	if providerSpec.Value == nil && providerSpec.ValueFrom == nil {
-		return nil, fmt.Errorf("unable to find machine provider config: neither Spec.ProviderConfig.Value nor Spec.ProviderConfig.ValueFrom set")
+		return nil, fmt.Errorf("unable to find machine provider config: neither Spec.ProviderSpec.Value nor Spec.ProviderSpec.ValueFrom set")
 	}
 
 	// If no providerSpec.Value then we lookup for machineClass
@@ -160,7 +151,7 @@ func providerConfigFromMachine(client client.Client, machine *clusterv1.Machine,
 		providerSpecRawExtention = *providerSpec.Value
 	} else {
 		if providerSpec.ValueFrom.MachineClass == nil {
-			return nil, fmt.Errorf("unable to find MachineClass on Spec.ProviderConfig.ValueFrom")
+			return nil, fmt.Errorf("unable to find MachineClass on Spec.ProviderSpec.ValueFrom")
 		}
 		machineClass := &clusterv1.MachineClass{}
 		key := types.NamespacedName{

--- a/pkg/actuators/machine/utils.go
+++ b/pkg/actuators/machine/utils.go
@@ -165,7 +165,7 @@ func providerConfigFromMachine(client client.Client, machine *clusterv1.Machine,
 	}
 
 	var config providerconfigv1.AWSMachineProviderConfig
-	if err := codec.DecodeProviderConfig(&clusterv1.ProviderSpec{Value: &providerSpecRawExtention}, &config); err != nil {
+	if err := codec.DecodeProviderSpec(&clusterv1.ProviderSpec{Value: &providerSpecRawExtention}, &config); err != nil {
 		return nil, err
 	}
 	return &config, nil

--- a/pkg/actuators/machine/utils_test.go
+++ b/pkg/actuators/machine/utils_test.go
@@ -50,7 +50,7 @@ func TestProviderConfigFromMachine(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	encodedProviderConfig, err := codec.EncodeProviderConfig(providerConfig)
+	encodedProviderSpec, err := codec.EncodeProviderSpec(providerConfig)
 	if err != nil {
 		t.Error(err)
 	}
@@ -60,7 +60,7 @@ func TestProviderConfigFromMachine(t *testing.T) {
 			Namespace: "openshift-cluster-api",
 			Name:      "testClass",
 		},
-		ProviderSpec: *encodedProviderConfig.Value,
+		ProviderSpec: *encodedProviderSpec.Value,
 	}
 
 	testCases := []struct {
@@ -79,7 +79,7 @@ func TestProviderConfigFromMachine(t *testing.T) {
 					Kind: "Machine",
 				},
 				Spec: clusterv1.MachineSpec{
-					ProviderSpec: *encodedProviderConfig,
+					ProviderSpec: *encodedProviderSpec,
 				},
 			},
 		},

--- a/pkg/apis/awsproviderconfig/v1alpha1/register.go
+++ b/pkg/apis/awsproviderconfig/v1alpha1/register.go
@@ -73,8 +73,8 @@ func NewCodec() (*AWSProviderConfigCodec, error) {
 	return &codec, nil
 }
 
-// DecodeProviderConfig deserialises an object from the provider config
-func (codec *AWSProviderConfigCodec) DecodeProviderConfig(providerSpec *clusterv1.ProviderSpec, out runtime.Object) error {
+// DecodeProviderSpec deserialises an object from the provider config
+func (codec *AWSProviderConfigCodec) DecodeProviderSpec(providerSpec *clusterv1.ProviderSpec, out runtime.Object) error {
 	if providerSpec.Value != nil {
 		_, _, err := codec.decoder.Decode(providerSpec.Value.Raw, nil, out)
 		if err != nil {
@@ -84,8 +84,8 @@ func (codec *AWSProviderConfigCodec) DecodeProviderConfig(providerSpec *clusterv
 	return nil
 }
 
-// EncodeProviderConfig serialises an object to the provider config
-func (codec *AWSProviderConfigCodec) EncodeProviderConfig(in runtime.Object) (*clusterv1.ProviderSpec, error) {
+// EncodeProviderSpec serialises an object to the provider config
+func (codec *AWSProviderConfigCodec) EncodeProviderSpec(in runtime.Object) (*clusterv1.ProviderSpec, error) {
 	var buf bytes.Buffer
 	if err := codec.encoder.Encode(in, &buf); err != nil {
 		return nil, fmt.Errorf("encoding failed: %v", err)

--- a/pkg/apis/awsproviderconfig/v1alpha1/register_test.go
+++ b/pkg/apis/awsproviderconfig/v1alpha1/register_test.go
@@ -66,7 +66,7 @@ func TestEncodeAndDecodeProviderStatus(t *testing.T) {
 	}
 }
 
-func TestEncodeAndDecodeProviderConfig(t *testing.T) {
+func TestEncodeAndDecodeProviderSpec(t *testing.T) {
 	codec, err := NewCodec()
 	if err != nil {
 		t.Fatal(err)
@@ -155,7 +155,7 @@ func TestEncodeAndDecodeProviderConfig(t *testing.T) {
 		},
 	}
 
-	providerConfigEncoded, err := codec.EncodeProviderConfig(providerConfig)
+	providerConfigEncoded, err := codec.EncodeProviderSpec(providerConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -163,20 +163,20 @@ func TestEncodeAndDecodeProviderConfig(t *testing.T) {
 	// Without deep copy
 	{
 		providerConfigDecoded := &AWSMachineProviderConfig{}
-		codec.DecodeProviderConfig(providerConfigEncoded, providerConfigDecoded)
+		codec.DecodeProviderSpec(providerConfigEncoded, providerConfigDecoded)
 
 		if !reflect.DeepEqual(providerConfig, providerConfigDecoded) {
-			t.Errorf("failed EncodeProviderConfig/DecodeProviderConfig. Expected: %+v, got: %+v", providerConfig, providerConfigDecoded)
+			t.Errorf("failed EncodeProviderSpec/DecodeProviderSpec. Expected: %+v, got: %+v", providerConfig, providerConfigDecoded)
 		}
 	}
 
 	// With deep copy
 	{
 		providerConfigDecoded := &AWSMachineProviderConfig{}
-		codec.DecodeProviderConfig(providerConfigEncoded, providerConfigDecoded)
+		codec.DecodeProviderSpec(providerConfigEncoded, providerConfigDecoded)
 
 		if !reflect.DeepEqual(providerConfig.DeepCopy(), providerConfigDecoded) {
-			t.Errorf("failed EncodeProviderConfig/DecodeProviderConfig. Expected: %+v, got: %+v", providerConfig, providerConfigDecoded)
+			t.Errorf("failed EncodeProviderSpec/DecodeProviderSpec. Expected: %+v, got: %+v", providerConfig, providerConfigDecoded)
 		}
 	}
 }

--- a/test/machines/machines_test.go
+++ b/test/machines/machines_test.go
@@ -129,9 +129,9 @@ var _ = framework.SigKubeDescribe("Machines", func() {
 
 		It("Can create AWS instances", func() {
 			// Create/delete a single machine, test instance is provisioned/terminated
-			testMachineProviderConfig, err := utils.TestingMachineProviderConfig(awsCredSecret.Name, cluster.Name)
+			testMachineProviderSpec, err := utils.TestingMachineProviderSpec(awsCredSecret.Name, cluster.Name)
 			Expect(err).NotTo(HaveOccurred())
-			testMachine := manifests.TestingMachine(cluster.Name, cluster.Namespace, testMachineProviderConfig)
+			testMachine := manifests.TestingMachine(cluster.Name, cluster.Namespace, testMachineProviderSpec)
 			f.CreateMachineAndWait(testMachine, acw)
 			machinesToDelete.AddMachine(testMachine, f, acw)
 
@@ -230,9 +230,9 @@ var _ = framework.SigKubeDescribe("Machines", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			createSecretAndWait(f, masterUserDataSecret)
-			masterMachineProviderConfig, err := utils.MasterMachineProviderConfig(awsCredSecret.Name, masterUserDataSecret.Name, cluster.Name)
+			masterMachineProviderSpec, err := utils.MasterMachineProviderSpec(awsCredSecret.Name, masterUserDataSecret.Name, cluster.Name)
 			Expect(err).NotTo(HaveOccurred())
-			masterMachine := manifests.MasterMachine(cluster.Name, cluster.Namespace, masterMachineProviderConfig)
+			masterMachine := manifests.MasterMachine(cluster.Name, cluster.Namespace, masterMachineProviderSpec)
 			f.CreateMachineAndWait(masterMachine, acw)
 			machinesToDelete.AddMachine(masterMachine, f, acw)
 
@@ -273,9 +273,9 @@ var _ = framework.SigKubeDescribe("Machines", func() {
 			workerUserDataSecret, err := manifests.WorkerMachineUserDataSecret("workeruserdatasecret", testNamespace.Name, masterPrivateIP)
 			Expect(err).NotTo(HaveOccurred())
 			createSecretAndWait(clusterFramework, workerUserDataSecret)
-			workerMachineSetProviderConfig, err := utils.WorkerMachineSetProviderConfig(awsCredSecret.Name, workerUserDataSecret.Name, cluster.Name)
+			workerMachineSetProviderSpec, err := utils.WorkerMachineSetProviderSpec(awsCredSecret.Name, workerUserDataSecret.Name, cluster.Name)
 			Expect(err).NotTo(HaveOccurred())
-			workerMachineSet := manifests.WorkerMachineSet(cluster.Name, cluster.Namespace, workerMachineSetProviderConfig)
+			workerMachineSet := manifests.WorkerMachineSet(cluster.Name, cluster.Namespace, workerMachineSetProviderSpec)
 			fmt.Printf("workerMachineSet: %#v\n", workerMachineSet)
 			clusterFramework.CreateMachineSetAndWait(workerMachineSet, acw)
 			machinesToDelete.AddMachineSet(workerMachineSet, clusterFramework, acw)

--- a/test/utils/manifests.go
+++ b/test/utils/manifests.go
@@ -25,7 +25,7 @@ func GenerateAwsCredentialsSecretFromEnv(secretName, namespace string) *apiv1.Se
 	}
 }
 
-func TestingMachineProviderConfig(awsCredentialsSecretName string, clusterID string) (clusterv1alpha1.ProviderSpec, error) {
+func TestingMachineProviderSpec(awsCredentialsSecretName string, clusterID string) (clusterv1alpha1.ProviderSpec, error) {
 	publicIP := true
 	machinePc := &providerconfigv1.AWSMachineProviderConfig{
 		AMI: providerconfigv1.AWSResourceReference{
@@ -98,7 +98,7 @@ func TestingMachineProviderConfig(awsCredentialsSecretName string, clusterID str
 	return *config, nil
 }
 
-func MasterMachineProviderConfig(awsCredentialsSecretName, masterUserDataSecretName, clusterID string) (clusterv1alpha1.ProviderSpec, error) {
+func MasterMachineProviderSpec(awsCredentialsSecretName, masterUserDataSecretName, clusterID string) (clusterv1alpha1.ProviderSpec, error) {
 	publicIP := true
 	machinePc := &providerconfigv1.AWSMachineProviderConfig{
 		AMI: providerconfigv1.AWSResourceReference{
@@ -160,7 +160,7 @@ func MasterMachineProviderConfig(awsCredentialsSecretName, masterUserDataSecretN
 	return *config, nil
 }
 
-func WorkerMachineSetProviderConfig(awsCredentialsSecretName, workerUserDataSecretName, clusterID string) (clusterv1alpha1.ProviderSpec, error) {
+func WorkerMachineSetProviderSpec(awsCredentialsSecretName, workerUserDataSecretName, clusterID string) (clusterv1alpha1.ProviderSpec, error) {
 	publicIP := true
 	machinePc := &providerconfigv1.AWSMachineProviderConfig{
 		AMI: providerconfigv1.AWSResourceReference{

--- a/test/utils/manifests.go
+++ b/test/utils/manifests.go
@@ -91,11 +91,11 @@ func TestingMachineProviderSpec(awsCredentialsSecretName string, clusterID strin
 	if err != nil {
 		return clusterv1alpha1.ProviderSpec{}, fmt.Errorf("failed creating codec: %v", err)
 	}
-	config, err := codec.EncodeProviderConfig(machinePc)
+	providerSpec, err := codec.EncodeProviderSpec(machinePc)
 	if err != nil {
-		return clusterv1alpha1.ProviderSpec{}, fmt.Errorf("EncodeToProviderConfig failed: %v", err)
+		return clusterv1alpha1.ProviderSpec{}, fmt.Errorf("codec.EncodeProviderSpec failed: %v", err)
 	}
-	return *config, nil
+	return *providerSpec, nil
 }
 
 func MasterMachineProviderSpec(awsCredentialsSecretName, masterUserDataSecretName, clusterID string) (clusterv1alpha1.ProviderSpec, error) {
@@ -153,11 +153,11 @@ func MasterMachineProviderSpec(awsCredentialsSecretName, masterUserDataSecretNam
 	if err != nil {
 		return clusterv1alpha1.ProviderSpec{}, fmt.Errorf("failed creating codec: %v", err)
 	}
-	config, err := codec.EncodeProviderConfig(machinePc)
+	providerSpec, err := codec.EncodeProviderSpec(machinePc)
 	if err != nil {
-		return clusterv1alpha1.ProviderSpec{}, fmt.Errorf("EncodeToProviderConfig failed: %v", err)
+		return clusterv1alpha1.ProviderSpec{}, fmt.Errorf("codec.EncodeProviderSpec failed: %v", err)
 	}
-	return *config, nil
+	return *providerSpec, nil
 }
 
 func WorkerMachineSetProviderSpec(awsCredentialsSecretName, workerUserDataSecretName, clusterID string) (clusterv1alpha1.ProviderSpec, error) {
@@ -215,9 +215,9 @@ func WorkerMachineSetProviderSpec(awsCredentialsSecretName, workerUserDataSecret
 	if err != nil {
 		return clusterv1alpha1.ProviderSpec{}, fmt.Errorf("failed creating codec: %v", err)
 	}
-	config, err := codec.EncodeProviderConfig(machinePc)
+	providerSpec, err := codec.EncodeProviderSpec(machinePc)
 	if err != nil {
-		return clusterv1alpha1.ProviderSpec{}, fmt.Errorf("EncodeToProviderConfig failed: %v", err)
+		return clusterv1alpha1.ProviderSpec{}, fmt.Errorf("codec.EncodeProviderSpec failed: %v", err)
 	}
-	return *config, nil
+	return *providerSpec, nil
 }

--- a/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/machine_types.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/machine_types.go
@@ -63,10 +63,6 @@ type MachineSpec struct {
 	// +optional
 	ProviderSpec ProviderSpec `json:"providerSpec"`
 
-	// Provider-specific configuration to use during node creation.
-	// +optional
-	ProviderConfig ProviderSpec `json:"providerConfig"`
-
 	// Versions of key software to use. This field is optional at cluster
 	// creation time, and omitting the field indicates that the cluster
 	// installation tool should select defaults for the user. These

--- a/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/zz_generated.deepcopy.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/zz_generated.deepcopy.go
@@ -632,7 +632,6 @@ func (in *MachineSpec) DeepCopyInto(out *MachineSpec) {
 		}
 	}
 	in.ProviderSpec.DeepCopyInto(&out.ProviderSpec)
-	in.ProviderConfig.DeepCopyInto(&out.ProviderConfig)
 	out.Versions = in.Versions
 	if in.ConfigSource != nil {
 		in, out := &in.ConfigSource, &out.ConfigSource


### PR DESCRIPTION
- remove any use of the `.providerConfig` and `ProviderConfig`
- rename testing resources to reflect new provider spec name
- rename [Encode|Decode]ProviderConfig to [Encode|Decode]ProviderSpec

/hold

until freeze is over and https://github.com/openshift/machine-api-operator/pull/170 is merged