### PR TITLE
Drain node if "openshift.io/drain-node" annotation key is set independent if its actual value

### DIFF
--- a/pkg/actuators/machine/actuator.go
+++ b/pkg/actuators/machine/actuator.go
@@ -254,7 +254,7 @@ func (gl *glogLogger) Logf(format string, v ...interface{}) {
 // DeleteMachine deletes an AWS instance
 func (a *Actuator) DeleteMachine(cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
 	// Drain node before deleting
-	if machine.ObjectMeta.Annotations["openshift.io/drain-node"] == "True" && machine.Status.NodeRef != nil {
+	if _, exists := machine.ObjectMeta.Annotations["openshift.io/drain-node"]; exists && machine.Status.NodeRef != nil {
 		glog.Infof("Draining node before delete")
 		if a.config == nil {
 			err := fmt.Errorf("missing client config, unable to build kube client")


### PR DESCRIPTION
The key is sufficient to enable the draining functionality.

/hold

Until https://github.com/openshift/installer/pull/1062#discussion_r247747301 is resolved.