### PR TITLE
Drain nodes by default unless explicitly set to exclude

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ build-e2e:
 .PHONY: k8s-e2e
 k8s-e2e: ## Run k8s specific e2e test
 	# KUBECONFIG and SSH_PK dirs needs to be mounted inside a container if tests are run in containers
-	go test -timeout 20m \
+	go test -timeout 30m \
 		-v sigs.k8s.io/cluster-api-provider-aws/test/machines \
 		-kubeconfig $${KUBECONFIG:-~/.kube/config} \
 		-ssh-key $${SSH_PK:-~/.ssh/id_rsa} \

--- a/pkg/actuators/machine/actuator.go
+++ b/pkg/actuators/machine/actuator.go
@@ -283,10 +283,11 @@ func (a *Actuator) DeleteMachine(cluster *machinev1.Cluster, machine *machinev1.
 		); err != nil {
 			// Machine still tries to terminate after drain failure
 			glog.Warningf("drain failed for machine %q: %v", machine.Name, err)
-		} else {
-			glog.Infof("drain successful for machine %q", machine.Name)
-			a.eventRecorder.Eventf(machine, corev1.EventTypeNormal, "Deleted", "Node %q drained", node.Name)
+			return &clustererror.RequeueAfterError{RequeueAfter: requeueAfterSeconds * time.Second}
 		}
+
+		glog.Infof("drain successful for machine %q", machine.Name)
+		a.eventRecorder.Eventf(machine, corev1.EventTypeNormal, "Deleted", "Node %q drained", node.Name)
 	}
 
 	machineProviderConfig, err := providerConfigFromMachine(a.client, machine, a.codec)

--- a/pkg/actuators/machine/stubs.go
+++ b/pkg/actuators/machine/stubs.go
@@ -117,6 +117,10 @@ func stubMachine() (*machinev1.Machine, error) {
 				providerconfigv1.MachineRoleLabel: "infra",
 				providerconfigv1.MachineTypeLabel: "master",
 			},
+			Annotations: map[string]string{
+				// skip node draining since it's not mocked
+				ExcludeNodeDrainingAnnotation: "",
+			},
 		},
 
 		Spec: machinev1.MachineSpec{

--- a/test/e2e/provider_expectations.go
+++ b/test/e2e/provider_expectations.go
@@ -251,15 +251,6 @@ func (tc *testConfig) ExpectNodeToBeDrainedBeforeDeletingMachine() error {
 		return err
 	}
 
-	glog.Info("Annotate machine with `openshift.io/drain-node` annotation")
-	if machine.ObjectMeta.Annotations == nil {
-		machine.ObjectMeta.Annotations = make(map[string]string)
-	}
-	machine.ObjectMeta.Annotations["openshift.io/drain-node"] = "True"
-	if err := tc.client.Update(context.TODO(), &machine); err != nil {
-		return fmt.Errorf("unable to set `drain-node` annotation")
-	}
-
 	glog.Info("Delete machine and observe node draining")
 	if err := tc.client.Delete(context.TODO(), &machine); err != nil {
 		return fmt.Errorf("unable to delete machine %q", machine.Name)

--- a/test/machines/machines_test.go
+++ b/test/machines/machines_test.go
@@ -132,6 +132,11 @@ var _ = framework.SigKubeDescribe("Machines", func() {
 			testMachineProviderSpec, err := utils.TestingMachineProviderSpec(awsCredSecret.Name, cluster.Name)
 			Expect(err).NotTo(HaveOccurred())
 			testMachine := manifests.TestingMachine(cluster.Name, cluster.Namespace, testMachineProviderSpec)
+			// Do not drain node (since it does not exist)
+			if testMachine.Annotations == nil {
+				testMachine.Annotations = map[string]string{}
+			}
+			testMachine.Annotations[machineutils.ExcludeNodeDrainingAnnotation] = ""
 			f.CreateMachineAndWait(testMachine, acw)
 			machinesToDelete.AddMachine(testMachine, f, acw)
 
@@ -205,6 +210,11 @@ var _ = framework.SigKubeDescribe("Machines", func() {
 			testMachineProviderSpec, err := utils.TestingMachineProviderSpecWithEBS(awsCredSecret.Name, cluster.Name)
 			Expect(err).NotTo(HaveOccurred())
 			testMachine := manifests.TestingMachine(cluster.Name, cluster.Namespace, testMachineProviderSpec)
+			// Do not drain node (since it does not exist)
+			if testMachine.Annotations == nil {
+				testMachine.Annotations = map[string]string{}
+			}
+			testMachine.Annotations[machineutils.ExcludeNodeDrainingAnnotation] = ""
 			f.CreateMachineAndWait(testMachine, acw)
 			machinesToDelete.AddMachine(testMachine, f, acw)
 
@@ -264,6 +274,11 @@ var _ = framework.SigKubeDescribe("Machines", func() {
 			masterMachineProviderSpec, err := utils.MasterMachineProviderSpec(awsCredSecret.Name, masterUserDataSecret.Name, cluster.Name)
 			Expect(err).NotTo(HaveOccurred())
 			masterMachine := manifests.MasterMachine(cluster.Name, cluster.Namespace, masterMachineProviderSpec)
+			// Do not drain node by default
+			if masterMachine.Annotations == nil {
+				masterMachine.Annotations = map[string]string{}
+			}
+			masterMachine.Annotations[machineutils.ExcludeNodeDrainingAnnotation] = ""
 			f.CreateMachineAndWait(masterMachine, acw)
 			machinesToDelete.AddMachine(masterMachine, f, acw)
 
@@ -307,6 +322,11 @@ var _ = framework.SigKubeDescribe("Machines", func() {
 			workerMachineSetProviderSpec, err := utils.WorkerMachineSetProviderSpec(awsCredSecret.Name, workerUserDataSecret.Name, cluster.Name)
 			Expect(err).NotTo(HaveOccurred())
 			workerMachineSet := manifests.WorkerMachineSet(cluster.Name, cluster.Namespace, workerMachineSetProviderSpec)
+			// Do not drain node by default
+			if workerMachineSet.Annotations == nil {
+				workerMachineSet.Annotations = map[string]string{}
+			}
+			workerMachineSet.Annotations[machineutils.ExcludeNodeDrainingAnnotation] = ""
 			fmt.Printf("workerMachineSet: %#v\n", workerMachineSet)
 			clusterFramework.CreateMachineSetAndWait(workerMachineSet, acw)
 			machinesToDelete.AddMachineSet(workerMachineSet, clusterFramework, acw)


### PR DESCRIPTION
So far a node was drained only when requested. From now on a node is drained by default unless "machine.openshift.io/exclude-node-draining" annotation key is specified. At the same time if a node draining is requested but a machine has no node reference, machine deletion is rejected.