### PR TITLE
Drop cluster test since it's not relevant for the actuator

### DIFF
--- a/test/e2e/main.go
+++ b/test/e2e/main.go
@@ -58,13 +58,6 @@ func runSuite() error {
 	}
 	glog.Info("PASS: ExpectProviderAvailable")
 
-	glog.Info("RUN: ExpectNoClusterObject")
-	if err := testConfig.ExpectNoClusterObject(); err != nil {
-		glog.Errorf("FAIL: ExpectNoClusterObject: %v", err)
-		return err
-	}
-	glog.Info("PASS: ExpectOneClusterObject")
-
 	glog.Info("RUN: ExpectAllMachinesLinkedToANode")
 	if err := testConfig.ExpectAllMachinesLinkedToANode(); err != nil {
 		glog.Errorf("FAIL: ExpectAllMachinesLinkedToANode: %v", err)

--- a/test/e2e/provider_expectations.go
+++ b/test/e2e/provider_expectations.go
@@ -40,25 +40,6 @@ func (tc *testConfig) ExpectProviderAvailable() error {
 	return err
 }
 
-func (tc *testConfig) ExpectNoClusterObject() error {
-	listOptions := client.ListOptions{
-		Namespace: namespace,
-	}
-	clusterList := mapiv1beta1.ClusterList{}
-
-	err := wait.PollImmediate(1*time.Second, waitShort, func() (bool, error) {
-		if err := tc.client.List(context.TODO(), &listOptions, &clusterList); err != nil {
-			glog.Errorf("error querying api for clusterList object: %v, retrying...", err)
-			return false, nil
-		}
-		if len(clusterList.Items) > 0 {
-			return false, errors.New("a cluster object was found")
-		}
-		return true, nil
-	})
-	return err
-}
-
 func (tc *testConfig) ExpectAllMachinesLinkedToANode() error {
 	machineAnnotationKey := "machine.openshift.io/machine"
 	listOptions := client.ListOptions{


### PR DESCRIPTION
Since this [openshift/installer@37b25ea#diff-a25ec653fe393c89c4ccac5a1edfe38fL51](https://github.com/openshift/installer/commit/37b25ea64964ad0671e6f498b57646efe641ad6f#diff-a25ec653fe393c89c4ccac5a1edfe38fL51) got in the cluster obejct needs to exist however is circumstantial for the actuator and no need to validate it exist or not here. See https://jira.coreos.com/browse/CLOUD-357

https://github.com/openshift/machine-api-operator/pull/216