### PR TITLE
deps: switch cluster-api dependency to use master branch

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -29,7 +29,7 @@ required = [
 
 [[override]]
   name = "github.com/openshift/cluster-api"
-  revision = "91fca585a85b163ddfd119fd09c128c9feadddca"
+  revision = "0c3e884db79556cf786aa8436f5be977ef10c211"
 
 [[override]]
   name = "k8s.io/code-generator"


### PR DESCRIPTION
Changing commit revision to point to openshift/cluster-api commit from master branch instead of `release-4.0` branch. Same as https://github.com/openshift/cluster-api-actuator-pkg/pull/30.
