### PR TITLE
Consistent log messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@
 
 # Auto-generated manifests
 tfManifests/
+
+bin/

--- a/cmd/aws-actuator/main.go
+++ b/cmd/aws-actuator/main.go
@@ -285,7 +285,7 @@ func bootstrapCommand() *cobra.Command {
 			}
 			result, err := actuator.CreateMachine(testCluster, masterMachine)
 			if err != nil {
-				glog.Errorf("unable to create machine: %v", err)
+				glog.Errorf("Unable to create machine: %v", err)
 				return fmt.Errorf("unable to create machine: %v", err)
 			}
 
@@ -300,7 +300,7 @@ func bootstrapCommand() *cobra.Command {
 					return false, nil
 				}
 
-				glog.Infof("PublicDnsName: %v\n", *result.PublicDnsName)
+				glog.Infof("PublicDNSName: %v", *result.PublicDnsName)
 				if *result.PublicDnsName == "" {
 					return false, nil
 				}

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -45,35 +45,34 @@ func main() {
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()
 	if err != nil {
-		glog.Fatal(err)
+		glog.Fatalf("Error getting configuration: %v", err)
 	}
 
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{})
 	if err != nil {
-		glog.Fatal(err)
+		glog.Fatalf("Error creating manager: %v", err)
 	}
-
-	glog.Info("Registering Components.")
 
 	// Setup Scheme for all resources
 	if err := clusterapis.AddToScheme(mgr.GetScheme()); err != nil {
-		glog.Fatal(err)
+		glog.Fatalf("Error setting up scheme: %v", err)
 	}
 
 	machineActuator, err := initActuator(mgr)
 	if err != nil {
-		glog.Fatal(err)
+		glog.Fatalf("Error initializing actuator: %v", err)
 	}
 
 	if err := machine.AddWithActuator(mgr, machineActuator); err != nil {
-		glog.Fatal(err)
+		glog.Fatalf("Error adding actuator: %v", err)
 	}
 
-	glog.Info("Starting the Cmd.")
-
 	// Start the Cmd
-	glog.Fatal(mgr.Start(signals.SetupSignalHandler()))
+	err = mgr.Start(signals.SetupSignalHandler())
+	if err != nil {
+		glog.Fatalf("Error starting manager: %v", err)
+	}
 }
 
 func initActuator(mgr manager.Manager) (*machineactuator.Actuator, error) {

--- a/pkg/actuators/machine/instances.go
+++ b/pkg/actuators/machine/instances.go
@@ -36,12 +36,12 @@ func removeDuplicatedTags(tags []*ec2.Tag) []*ec2.Tag {
 func removeStoppedMachine(machine *machinev1.Machine, client awsclient.Client) error {
 	instances, err := getStoppedInstances(machine, client)
 	if err != nil {
-		glog.Errorf("error getting stopped instances: %v", err)
+		glog.Errorf("Error getting stopped instances: %v", err)
 		return fmt.Errorf("error getting stopped instances: %v", err)
 	}
 
 	if len(instances) == 0 {
-		glog.Infof("no stopped instances found for machine %v", machine.Name)
+		glog.Infof("No stopped instances found for machine %v", machine.Name)
 		return nil
 	}
 
@@ -188,11 +188,11 @@ func getBlockDeviceMappings(blockDeviceMappings []providerconfigv1.BlockDeviceMa
 	}
 	describeAMIResult, err := client.DescribeImages(&describeImagesRequest)
 	if err != nil {
-		glog.Errorf("error describing AMI: %v", err)
+		glog.Errorf("Error describing AMI: %v", err)
 		return nil, fmt.Errorf("error describing AMI: %v", err)
 	}
 	if len(describeAMIResult.Images) < 1 {
-		glog.Errorf("no image for given AMI was found")
+		glog.Errorf("No image for given AMI was found")
 		return nil, fmt.Errorf("no image for given AMI not found")
 	}
 	deviceName := describeAMIResult.Images[0].RootDeviceName
@@ -249,7 +249,7 @@ func launchInstance(machine *machinev1.Machine, machineProviderConfig *providerc
 
 	clusterID, ok := getClusterID(machine)
 	if !ok {
-		glog.Errorf("unable to get cluster ID for machine: %q", machine.Name)
+		glog.Errorf("Unable to get cluster ID for machine: %q", machine.Name)
 		return nil, err
 	}
 	// Add tags to the created machine
@@ -307,12 +307,12 @@ func launchInstance(machine *machinev1.Machine, machineProviderConfig *providerc
 	}
 	runResult, err := client.RunInstances(&inputConfig)
 	if err != nil {
-		glog.Errorf("error creating EC2 instance: %v", err)
+		glog.Errorf("Error creating EC2 instance: %v", err)
 		return nil, fmt.Errorf("error creating EC2 instance: %v", err)
 	}
 
 	if runResult == nil || len(runResult.Instances) != 1 {
-		glog.Errorf("unexpected reservation creating instances: %v", runResult)
+		glog.Errorf("Unexpected reservation creating instances: %v", runResult)
 		return nil, fmt.Errorf("unexpected reservation creating instance")
 	}
 

--- a/pkg/actuators/machine/loadbalancers.go
+++ b/pkg/actuators/machine/loadbalancers.go
@@ -48,19 +48,19 @@ func registerWithNetworkLoadBalancers(client awsclient.Client, names []string, i
 	}
 	lbsResponse, err := client.ELBv2DescribeLoadBalancers(lbsRequest)
 	if err != nil {
-		glog.Errorf("failed to describe load balancers %v: %v", names, err)
+		glog.Errorf("Failed to describe load balancers %v: %v", names, err)
 		return err
 	}
 	// Use a map for target groups to get unique target group entries across load balancers
 	targetGroups := map[string]*elbv2.TargetGroup{}
 	for _, loadBalancer := range lbsResponse.LoadBalancers {
-		glog.V(4).Infof("retrieving target groups for load balancer %q", *loadBalancer.LoadBalancerName)
+		glog.V(4).Infof("Retrieving target groups for load balancer %q", *loadBalancer.LoadBalancerName)
 		targetGroupsInput := &elbv2.DescribeTargetGroupsInput{
 			LoadBalancerArn: loadBalancer.LoadBalancerArn,
 		}
 		targetGroupsOutput, err := client.ELBv2DescribeTargetGroups(targetGroupsInput)
 		if err != nil {
-			glog.Errorf("failed to retrieve load balancer target groups for %q: %v", *loadBalancer.LoadBalancerName, err)
+			glog.Errorf("Failed to retrieve load balancer target groups for %q: %v", *loadBalancer.LoadBalancerName, err)
 			return err
 		}
 		for _, targetGroup := range targetGroupsOutput.TargetGroups {
@@ -72,7 +72,7 @@ func registerWithNetworkLoadBalancers(client awsclient.Client, names []string, i
 		for arn := range targetGroups {
 			targetGroupArns = append(targetGroupArns, fmt.Sprintf("%q", arn))
 		}
-		glog.Infof("registering instance %q with target groups: %v", *instance.InstanceId, strings.Join(targetGroupArns, ","))
+		glog.Infof("Registering instance %q with target groups: %v", *instance.InstanceId, strings.Join(targetGroupArns, ","))
 	}
 	errs := []error{}
 	for _, targetGroup := range targetGroups {
@@ -93,7 +93,7 @@ func registerWithNetworkLoadBalancers(client awsclient.Client, names []string, i
 		}
 		_, err := client.ELBv2RegisterTargets(registerTargetsInput)
 		if err != nil {
-			glog.Errorf("failed to register instance %q with target group %q: %v", *instance.InstanceId, *targetGroup.TargetGroupArn, err)
+			glog.Errorf("Failed to register instance %q with target group %q: %v", *instance.InstanceId, *targetGroup.TargetGroupArn, err)
 			errs = append(errs, fmt.Errorf("%s: %v", *targetGroup.TargetGroupArn, err))
 		}
 	}

--- a/pkg/actuators/machine/utils.go
+++ b/pkg/actuators/machine/utils.go
@@ -146,7 +146,7 @@ func terminateInstances(client awsclient.Client, instances []*ec2.Instance) erro
 	}
 	_, err := client.TerminateInstances(terminateInstancesRequest)
 	if err != nil {
-		glog.Errorf("error terminating instances: %v", err)
+		glog.Errorf("Error terminating instances: %v", err)
 		return fmt.Errorf("error terminating instances: %v", err)
 	}
 	return nil


### PR DESCRIPTION
Based on https://github.com/openshift/machine-api-operator/pull/231

- https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md
- if an error message is just printed, use uppercase
- if an error message is return by a function/method and passed on, use lowercase
- NOUN VERB STATE format when possible

/assign @ingvagabund 