### PR TITLE
Move node draining from actuator into machine controller

### DIFF
--- a/pkg/actuators/machine/stubs.go
+++ b/pkg/actuators/machine/stubs.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	machinev1 "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
+	machinecontroller "github.com/openshift/cluster-api/pkg/controller/machine"
 	providerconfigv1 "sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-aws/test/utils"
 )
@@ -119,7 +120,7 @@ func stubMachine() (*machinev1.Machine, error) {
 			},
 			Annotations: map[string]string{
 				// skip node draining since it's not mocked
-				ExcludeNodeDrainingAnnotation: "",
+				machinecontroller.ExcludeNodeDrainingAnnotation: "",
 			},
 		},
 

--- a/test/machines/machines_test.go
+++ b/test/machines/machines_test.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/test/utils"
 
 	MachineV1beta1 "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
+	machinecontroller "github.com/openshift/cluster-api/pkg/controller/machine"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -136,7 +137,7 @@ var _ = framework.SigKubeDescribe("Machines", func() {
 			if testMachine.Annotations == nil {
 				testMachine.Annotations = map[string]string{}
 			}
-			testMachine.Annotations[machineutils.ExcludeNodeDrainingAnnotation] = ""
+			testMachine.Annotations[machinecontroller.ExcludeNodeDrainingAnnotation] = ""
 			f.CreateMachineAndWait(testMachine, acw)
 			machinesToDelete.AddMachine(testMachine, f, acw)
 
@@ -214,7 +215,7 @@ var _ = framework.SigKubeDescribe("Machines", func() {
 			if testMachine.Annotations == nil {
 				testMachine.Annotations = map[string]string{}
 			}
-			testMachine.Annotations[machineutils.ExcludeNodeDrainingAnnotation] = ""
+			testMachine.Annotations[machinecontroller.ExcludeNodeDrainingAnnotation] = ""
 			f.CreateMachineAndWait(testMachine, acw)
 			machinesToDelete.AddMachine(testMachine, f, acw)
 
@@ -278,7 +279,7 @@ var _ = framework.SigKubeDescribe("Machines", func() {
 			if masterMachine.Annotations == nil {
 				masterMachine.Annotations = map[string]string{}
 			}
-			masterMachine.Annotations[machineutils.ExcludeNodeDrainingAnnotation] = ""
+			masterMachine.Annotations[machinecontroller.ExcludeNodeDrainingAnnotation] = ""
 			f.CreateMachineAndWait(masterMachine, acw)
 			machinesToDelete.AddMachine(masterMachine, f, acw)
 
@@ -326,7 +327,7 @@ var _ = framework.SigKubeDescribe("Machines", func() {
 			if workerMachineSet.Annotations == nil {
 				workerMachineSet.Annotations = map[string]string{}
 			}
-			workerMachineSet.Annotations[machineutils.ExcludeNodeDrainingAnnotation] = ""
+			workerMachineSet.Annotations[machinecontroller.ExcludeNodeDrainingAnnotation] = ""
 			fmt.Printf("workerMachineSet: %#v\n", workerMachineSet)
 			clusterFramework.CreateMachineSetAndWait(workerMachineSet, acw)
 			machinesToDelete.AddMachineSet(workerMachineSet, clusterFramework, acw)

--- a/vendor/github.com/openshift/cluster-api/pkg/controller/machine/controller.go
+++ b/vendor/github.com/openshift/cluster-api/pkg/controller/machine/controller.go
@@ -19,16 +19,24 @@ package machine
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
+	"time"
 
+	"github.com/go-log/log/info"
 	machinev1 "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
 	controllerError "github.com/openshift/cluster-api/pkg/controller/error"
 	"github.com/openshift/cluster-api/pkg/util"
+	kubedrain "github.com/openshift/kubernetes-drain"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/klog"
+	"k8s.io/klog/glog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -37,7 +45,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-const NodeNameEnvVar = "NODE_NAME"
+const (
+	NodeNameEnvVar = "NODE_NAME"
+
+	// ExcludeNodeDrainingAnnotation annotation explicitly skips node draining if set
+	ExcludeNodeDrainingAnnotation = "machine.openshift.io/exclude-node-draining"
+)
 
 var DefaultActuator Actuator
 
@@ -48,10 +61,12 @@ func AddWithActuator(mgr manager.Manager, actuator Actuator) error {
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager, actuator Actuator) reconcile.Reconciler {
 	r := &ReconcileMachine{
-		Client:   mgr.GetClient(),
-		scheme:   mgr.GetScheme(),
-		nodeName: os.Getenv(NodeNameEnvVar),
-		actuator: actuator,
+		Client:        mgr.GetClient(),
+		eventRecorder: mgr.GetRecorder("machine-controller"),
+		config:        mgr.GetConfig(),
+		scheme:        mgr.GetScheme(),
+		nodeName:      os.Getenv(NodeNameEnvVar),
+		actuator:      actuator,
 	}
 
 	if r.nodeName == "" {
@@ -83,7 +98,10 @@ var _ reconcile.Reconciler = &ReconcileMachine{}
 // ReconcileMachine reconciles a Machine object
 type ReconcileMachine struct {
 	client.Client
+	config *rest.Config
 	scheme *runtime.Scheme
+
+	eventRecorder record.EventRecorder
 
 	actuator Actuator
 
@@ -145,6 +163,51 @@ func (r *ReconcileMachine) Reconcile(request reconcile.Request) (reconcile.Resul
 			return reconcile.Result{}, nil
 		}
 		klog.Infof("reconciling machine object %v triggers delete.", name)
+
+		// Drain node before deletion
+		// If a machine is not linked to a node, just delete the machine. Since a node
+		// can be unlinked from a machine when the node goes NotReady and is removed
+		// by cloud controller manager. In that case some machines would never get
+		// deleted without a manual intervention.
+		if _, exists := m.ObjectMeta.Annotations[ExcludeNodeDrainingAnnotation]; !exists && m.Status.NodeRef != nil {
+			if err := func() error {
+				kubeClient, err := kubernetes.NewForConfig(r.config)
+				if err != nil {
+					return fmt.Errorf("unable to build kube client: %v", err)
+				}
+				node, err := kubeClient.CoreV1().Nodes().Get(m.Status.NodeRef.Name, metav1.GetOptions{})
+				if err != nil {
+					return fmt.Errorf("unable to get node %q: %v", m.Status.NodeRef.Name, err)
+				}
+
+				if err := kubedrain.Drain(
+					kubeClient,
+					[]*corev1.Node{node},
+					&kubedrain.DrainOptions{
+						Force:              true,
+						IgnoreDaemonsets:   true,
+						DeleteLocalData:    true,
+						GracePeriodSeconds: -1,
+						Logger:             info.New(glog.V(0)),
+						// If a pod is not evicted in 20 second, retry the eviction next time the
+						// machine gets reconciled again (to allow other machines to be reconciled)
+						Timeout: 20 * time.Second,
+					},
+				); err != nil {
+					// Machine still tries to terminate after drain failure
+					glog.Warningf("drain failed for machine %q: %v", m.Name, err)
+					return &controllerError.RequeueAfterError{RequeueAfter: 20 * time.Second}
+				}
+
+				glog.Infof("drain successful for machine %q", m.Name)
+				r.eventRecorder.Eventf(m, corev1.EventTypeNormal, "Deleted", "Node %q drained", node.Name)
+
+				return nil
+			}(); err != nil {
+				return reconcile.Result{}, err
+			}
+		}
+
 		if err := r.actuator.Delete(ctx, cluster, m); err != nil {
 			klog.Errorf("Error deleting machine object %v; %v", name, err)
 			if requeueErr, ok := err.(*controllerError.RequeueAfterError); ok {


### PR DESCRIPTION
Node draining is a generic operation independent of a specific actuator.
Thus, it makes sense to move the code from actuator into the machine controllers.
The node draining code itself is imported from github.com/openshift/kubernetes-drain.

At the same time it's currently impossible to use the controller-runtime client for node draining
due to missing Patch operation (https://github.com/kubernetes-sigs/controller-runtime/pull/235).
Thus, the machine controller needs to initialize kubeclient as well in order to
implement the node draining logic. Once the Patch operation is implemented,
the draining logic can be updated to replace kube client with controller runtime client.

Also, initialize event recorder to generate node draining event.

Corresponding openshift upstream PR here: https://github.com/openshift/cluster-api/pull/11