### PR TITLE
Reduce resync period from 10 hours to 10 minutes

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -16,6 +16,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"time"
 
 	"github.com/golang/glog"
 	clusterapis "github.com/openshift/cluster-api/pkg/apis"
@@ -49,7 +50,10 @@ func main() {
 	}
 
 	// Create a new Cmd to provide shared dependencies and start components
-	mgr, err := manager.New(cfg, manager.Options{})
+	syncPeriod := 10 * time.Minute
+	mgr, err := manager.New(cfg, manager.Options{
+		SyncPeriod: &syncPeriod,
+	})
 	if err != nil {
 		glog.Fatalf("Error creating manager: %v", err)
 	}


### PR DESCRIPTION
Currently resync is set to 10 hours https://github.com/kubernetes-sigs/cluster-api/blob/master/vendor/sigs.k8s.io/controller-runtime/pkg/cache/cache.go#L88 which makes external provider state changes almost ignored by the controller. This PR makes reconciling to happen more frequently
https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/671