### PR TITLE
Do not be explicit about iops constraints

### DIFF
--- a/pkg/apis/awsproviderconfig/v1beta1/awsmachineproviderconfig_types.go
+++ b/pkg/apis/awsproviderconfig/v1beta1/awsmachineproviderconfig_types.go
@@ -190,8 +190,9 @@ type EBSBlockDeviceSpec struct {
 	// and bursting, see Amazon EBS Volume Types (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
 	// in the Amazon Elastic Compute Cloud User Guide.
 	//
-	// Constraint: Range is 100-20000 IOPS for io1 volumes and 100-10000 IOPS for
-	// gp2 volumes.
+	// Minimal and maximal IOPS for io1 and gp2 are constrained. Please, check
+	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html
+	// for precise boundaries for individual volumes.
 	//
 	// Condition: This parameter is required for requests to create io1 volumes;
 	// it is not used in requests to create gp2, st1, sc1, or standard volumes.


### PR DESCRIPTION
IOPS constrained for individual volumes may vary over time.
Rather, direct a reader to the AWS documentation instead of
explicitly stating the boundaries.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1691208