### PR TITLE
fix source paths when invoking vet and fmt scripts

### DIFF
--- a/hack/go-fmt.sh
+++ b/hack/go-fmt.sh
@@ -9,8 +9,8 @@ if [ "$IS_CONTAINER" != "" ]; then
 else
   docker run -it --rm \
     --env IS_CONTAINER=TRUE \
-    --volume "${PWD}:/go/src/github.com/openshift/${REPO_NAME}:z" \
-    --workdir "/go/src/github.com/openshift/${REPO_NAME}" \
+    --volume "${PWD}:/go/src/sigs.k8s.io/${REPO_NAME}:z" \
+    --workdir "/go/src/sigs.k8s.io/${REPO_NAME}" \
     openshift/origin-release:golang-1.10 \
     ./hack/go-fmt.sh "${@}"
 fi

--- a/hack/go-vet.sh
+++ b/hack/go-vet.sh
@@ -5,8 +5,8 @@ if [ "$IS_CONTAINER" != "" ]; then
 else
   docker run --rm \
     --env IS_CONTAINER=TRUE \
-    --volume "${PWD}:/go/src/github.com/openshift/${REPO_NAME}:z" \
-    --workdir "/go/src/github.com/openshift/${REPO_NAME}" \
+    --volume "${PWD}:/go/src/sigs.k8s.io/${REPO_NAME}:z" \
+    --workdir "/go/src/sigs.k8s.io/${REPO_NAME}" \
     openshift/origin-release:golang-1.10 \
     ./hack/go-vet.sh "${@}"
 fi;


### PR DESCRIPTION
Running `make vet` yields:

```console
$ make vet
hack/go-vet.sh ./...
cmd/aws-actuator/main.go:45:2: cannot find package "sigs.k8s.io/cluster-api-provider-aws/pkg/actuators/machine" in any of:
	/go/src/github.com/openshift/cluster-api-provider-aws/vendor/sigs.k8s.io/cluster-api-provider-aws/pkg/actuators/machine (vendor tree)
	/usr/local/go/src/sigs.k8s.io/cluster-api-provider-aws/pkg/actuators/machine (from $GOROOT)
	/go/src/sigs.k8s.io/cluster-api-provider-aws/pkg/actuators/machine (from $GOPATH)
cmd/aws-actuator/utils.go:22:2: cannot find package "sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1beta1" in any of:
	/go/src/github.com/openshift/cluster-api-provider-aws/vendor/sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1beta1 (vendor tree)
	/usr/local/go/src/sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1beta1 (from $GOROOT)
	/go/src/sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1beta1 (from $GOPATH)
cmd/aws-actuator/main.go:46:2: cannot find package "sigs.k8s.io/cluster-api-provider-aws/pkg/client" in any of:
	/go/src/github.com/openshift/cluster-api-provider-aws/vendor/sigs.k8s.io/cluster-api-provider-aws/pkg/client (vendor tree)
	/usr/local/go/src/sigs.k8s.io/cluster-api-provider-aws/pkg/client (from $GOROOT)
	/go/src/sigs.k8s.io/cluster-api-provider-aws/pkg/client (from $GOPATH)
cmd/aws-actuator/main.go:47:2: cannot find package "sigs.k8s.io/cluster-api-provider-aws/test/utils" in any of:
	/go/src/github.com/openshift/cluster-api-provider-aws/vendor/sigs.k8s.io/cluster-api-provider-aws/test/utils (vendor tree)
	/usr/local/go/src/sigs.k8s.io/cluster-api-provider-aws/test/utils (from $GOROOT)
	/go/src/sigs.k8s.io/cluster-api-provider-aws/test/utils (from $GOPATH)
make: *** [Makefile:129: vet] Error 1
```