### PR TITLE
Include stopped instances in Exists call

### DIFF
--- a/pkg/actuators/machine/utils.go
+++ b/pkg/actuators/machine/utils.go
@@ -55,6 +55,13 @@ func getRunningInstances(machine *machinev1.Machine, client awsclient.Client) ([
 	return getInstances(machine, client, runningInstanceStateFilter)
 }
 
+// getExistingInstances returns all non-terminated instances that have a tag
+// matching our machine name and cluster ID.
+func getExistingInstances(machine *machinev1.Machine, client awsclient.Client) ([]*ec2.Instance, error) {
+	runningInstanceStateFilter := []*string{aws.String(ec2.InstanceStateNameRunning), aws.String(ec2.InstanceStateNamePending), aws.String(ec2.InstanceStateNameStopped), aws.String(ec2.InstanceStateNameStopping), aws.String(ec2.InstanceStateNameShuttingDown)}
+	return getInstances(machine, client, runningInstanceStateFilter)
+}
+
 // getStoppedInstances returns all stopped instances that have a tag matching our machine name,
 // and cluster ID.
 func getStoppedInstances(machine *machinev1.Machine, client awsclient.Client) ([]*ec2.Instance, error) {


### PR DESCRIPTION
This commit includes all instance states except 'terminated'
when the machine-controller Reconcile loop calls the
actuator Exists() function.  This ensures we do not
create a duplicate instance in the case where an
instance might have been stopped by the administrator
or other reason.