### PR TITLE
Consider stopped, stopping and shutting-down instances to be existing

### DIFF
--- a/pkg/actuators/machine/actuator.go
+++ b/pkg/actuators/machine/actuator.go
@@ -427,7 +427,7 @@ func (a *Actuator) getMachineInstances(cluster *clusterv1.Cluster, machine *mach
 		return nil, fmt.Errorf("error getting EC2 client: %v", err)
 	}
 
-	return getRunningInstances(machine, client)
+	return getExistingInstances(machine, client)
 }
 
 // updateLoadBalancers adds a given machine instance to the load balancers specified in its provider config

--- a/pkg/actuators/machine/utils.go
+++ b/pkg/actuators/machine/utils.go
@@ -62,6 +62,16 @@ func getStoppedInstances(machine *machinev1.Machine, client awsclient.Client) ([
 	return getInstances(machine, client, stoppedInstanceStateFilter)
 }
 
+func getExistingInstances(machine *machinev1.Machine, client awsclient.Client) ([]*ec2.Instance, error) {
+	return getInstances(machine, client, []*string{
+		aws.String(ec2.InstanceStateNameRunning),
+		aws.String(ec2.InstanceStateNamePending),
+		aws.String(ec2.InstanceStateNameStopped),
+		aws.String(ec2.InstanceStateNameStopping),
+		aws.String(ec2.InstanceStateNameShuttingDown),
+	})
+}
+
 // getInstances returns all instances that have a tag matching our machine name,
 // and cluster ID.
 func getInstances(machine *machinev1.Machine, client awsclient.Client, instanceStateFilter []*string) ([]*ec2.Instance, error) {


### PR DESCRIPTION
Currently, any non-existing instance is recreated during machine reconciliation.
In case an AWS instance is stopped for maintenance purposes, it is considered
as it would be terminated. Which is not the expected behaviour.
Instead, consider such instance to be existing until its status changes back to
running or is terminated.

Side effect: stopped worker machines will not get reconciled.