### PR TITLE
Fix CI/jenkins e2e env setup

### DIFF
--- a/hack/prebuild/main.tf
+++ b/hack/prebuild/main.tf
@@ -12,6 +12,7 @@ module "vpc" {
   azs             = "${data.aws_availability_zones.azs.names}"
   public_subnets  = "${var.vpc_public_networks}"
   private_subnets = "${var.vpc_private_networks}"
+  version         = "~> 1.66.0"
 
   public_subnet_tags = {
     Name = "${var.environment_id}"


### PR DESCRIPTION
```
31mError downloading modules: Error loading modules: module vpc: Error parsing .terraform/modules/2b0dfe72e06da71d934d6da6693d5852/terraform-aws-modules-terraform-aws-vpc-e99089a/main.tf: At 2:23: Unknown token: 2:23 IDENT max[0m[0m
```
And because of this error in `terraform init` subnet is not getting created which results in machine creation failure:

```
E0531 11:44:08.153778       1 actuator.go:104] Machine error: error launching instance: error getting subnet IDs: no subnet IDs were found,
E0531 11:44:08.153804       1 actuator.go:113] error creating machine: error launching instance: error getting subnet IDs: no subnet IDs were found,
```
 
Related: https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/267#issuecomment-495858008