### PR TITLE
Bug 1729243: Update vendor kubernetes-drain

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -536,11 +536,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:f7646c654e93258958dba300641f8f674d5a9ed015c11119793ba1156e2acbe9"
+  digest = "1:b79de44700bc7fc32b4f898e283754fa027616f87074be1cf65a7be5a961cc85"
   name = "github.com/openshift/kubernetes-drain"
   packages = ["."]
   pruneopts = "T"
-  revision = "c2e51be1758efa30d71a4d30dc4e2db86b70a4df"
+  revision = "4b061affbd00bfc62036a5cd3a57493db6c94151"
 
 [[projects]]
   branch = "master"

--- a/vendor/github.com/openshift/kubernetes-drain/drain.go
+++ b/vendor/github.com/openshift/kubernetes-drain/drain.go
@@ -399,7 +399,7 @@ func deleteOrEvictPods(client kubernetes.Interface, pods []corev1.Pod, options *
 	}
 
 	getPodFn := func(namespace, name string) (*corev1.Pod, error) {
-		return client.CoreV1().Pods(options.Namespace).Get(name, metav1.GetOptions{})
+		return client.CoreV1().Pods(namespace).Get(name, metav1.GetOptions{})
 	}
 
 	if len(policyGroupVersion) > 0 {


### PR DESCRIPTION
This commit fixes a bug where drain does not wait for
completion of eviction or deletion of pods due to
missing namespace attribute when checking if pod still
exists after drain operation.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1729243
Backports: 394c11e22a3474453d05a3227f40540f2d76c9c6
Backports: https://github.com/openshift/cluster-api-provider-aws/pull/237