### PR TITLE
Set additional machine annotations/labels to get pretty machine output

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -459,7 +459,7 @@
 
 [[projects]]
   branch = "openshift-4.2-cluster-api-0.1.0"
-  digest = "1:54dfec845e2fb5631fa1fc556a677a473a7efe663df4a4808621dca5e0358b23"
+  digest = "1:e4cc8b4a309af144c12f7e010efe4de2a3068cbb141a856bc2e662608683d3f3"
   name = "github.com/openshift/cluster-api"
   packages = [
     "pkg/apis",
@@ -479,7 +479,7 @@
     "pkg/util",
   ]
   pruneopts = "T"
-  revision = "72ebbaa0456c052d886259dc26420644178a0c5f"
+  revision = "f8de78af80fcecf1fd69e35005b591dc9e1df61a"
 
 [[projects]]
   branch = "master"

--- a/pkg/actuators/machine/instances.go
+++ b/pkg/actuators/machine/instances.go
@@ -45,7 +45,8 @@ func removeStoppedMachine(machine *machinev1.Machine, client awsclient.Client) e
 		return nil
 	}
 
-	return terminateInstances(client, instances)
+	_, err = terminateInstances(client, instances)
+	return err
 }
 
 func buildEC2Filters(inputFilters []providerconfigv1.Filter) []*ec2.Filter {

--- a/vendor/github.com/openshift/cluster-api/config/crds/machine_v1beta1_machine.yaml
+++ b/vendor/github.com/openshift/cluster-api/config/crds/machine_v1beta1_machine.yaml
@@ -6,6 +6,37 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: machines.machine.openshift.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.annotations['machine\.openshift\.io/instance-state']
+    description: State of instance
+    name: State
+    type: string
+  - JSONPath: .metadata.labels['machine\.openshift\.io/instance-type']
+    description: Type of instance
+    name: Type
+    type: string
+  - JSONPath: .metadata.labels['machine\.openshift\.io/region']
+    description: Region associated with machine
+    name: Region
+    type: string
+  - JSONPath: .metadata.labels['machine\.openshift\.io/zone']
+    description: Zone associated with machine
+    name: Zone
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Machine age
+    name: Age
+    type: date
+  - JSONPath: .status.nodeRef.name
+    description: Node associated with machine
+    name: Node
+    priority: 1
+    type: string
+  - JSONPath: .spec.providerID
+    description: Provider ID of machine created in cloud provider
+    name: ProviderID
+    priority: 1
+    type: string
   group: machine.openshift.io
   names:
     kind: Machine

--- a/vendor/github.com/openshift/cluster-api/config/crds/machine_v1beta1_machineset.yaml
+++ b/vendor/github.com/openshift/cluster-api/config/crds/machine_v1beta1_machineset.yaml
@@ -6,6 +6,27 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: machinesets.machine.openshift.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.replicas
+    description: Desired Replicas
+    name: Desired
+    type: integer
+  - JSONPath: .status.replicas
+    description: Current Replicas
+    name: Current
+    type: integer
+  - JSONPath: .status.readyReplicas
+    description: Ready Replicas
+    name: Ready
+    type: integer
+  - JSONPath: .status.availableReplicas
+    description: Observed number of available replicas
+    name: Available
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Machineset age
+    name: Age
+    type: date
   group: machine.openshift.io
   names:
     kind: MachineSet

--- a/vendor/github.com/openshift/cluster-api/pkg/apis/machine/v1beta1/machine_types.go
+++ b/vendor/github.com/openshift/cluster-api/pkg/apis/machine/v1beta1/machine_types.go
@@ -46,6 +46,13 @@ const (
 // Machine is the Schema for the machines API
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="State",type="string",JSONPath=".metadata.annotations['machine\.openshift\.io/instance-state']",description="State of instance"
+// +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".metadata.labels['machine\.openshift\.io/instance-type']",description="Type of instance"
+// +kubebuilder:printcolumn:name="Region",type="string",JSONPath=".metadata.labels['machine\.openshift\.io/region']",description="Region associated with machine"
+// +kubebuilder:printcolumn:name="Zone",type="string",JSONPath=".metadata.labels['machine\.openshift\.io/zone']",description="Zone associated with machine"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Machine age"
+// +kubebuilder:printcolumn:name="Node",type="string",JSONPath=".status.nodeRef.name",description="Node associated with machine",priority=1
+// +kubebuilder:printcolumn:name="ProviderID",type="string",JSONPath=".spec.providerID",description="Provider ID of machine created in cloud provider",priority=1
 type Machine struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/vendor/github.com/openshift/cluster-api/pkg/apis/machine/v1beta1/machineset_types.go
+++ b/vendor/github.com/openshift/cluster-api/pkg/apis/machine/v1beta1/machineset_types.go
@@ -35,6 +35,11 @@ import (
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.labelSelector
+// +kubebuilder:printcolumn:name="Desired",type="integer",JSONPath=".spec.replicas",description="Desired Replicas"
+// +kubebuilder:printcolumn:name="Current",type="integer",JSONPath=".status.replicas",description="Current Replicas"
+// +kubebuilder:printcolumn:name="Ready",type="integer",JSONPath=".status.readyReplicas",description="Ready Replicas"
+// +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.availableReplicas",description="Observed number of available replicas"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Machineset age"
 type MachineSet struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/vendor/github.com/openshift/cluster-api/pkg/controller/machine/controller.go
+++ b/vendor/github.com/openshift/cluster-api/pkg/controller/machine/controller.go
@@ -49,6 +49,18 @@ const (
 
 	// ExcludeNodeDrainingAnnotation annotation explicitly skips node draining if set
 	ExcludeNodeDrainingAnnotation = "machine.openshift.io/exclude-node-draining"
+
+	// MachineRegionLabelName as annotation name for a machine region
+	MachineRegionLabelName = "machine.openshift.io/region"
+
+	// MachineAZLabelName as annotation name for a machine AZ
+	MachineAZLabelName = "machine.openshift.io/zone"
+
+	// MachineInstanceStateAnnotationName as annotation name for a machine instance state
+	MachineInstanceStateAnnotationName = "machine.openshift.io/instance-state"
+
+	// MachineInstanceTypeLabelName as annotation name for a machine instance type
+	MachineInstanceTypeLabelName = "machine.openshift.io/instance-type"
 )
 
 var DefaultActuator Actuator

--- a/vendor/github.com/openshift/cluster-api/pkg/controller/machinedeployment/controller.go
+++ b/vendor/github.com/openshift/cluster-api/pkg/controller/machinedeployment/controller.go
@@ -173,6 +173,13 @@ func (r *ReconcileMachineDeployment) Reconcile(request reconcile.Request) (recon
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
 	}
+
+	// Ignore deleted MachineDeployments, this can happen when foregroundDeletion
+	// is enabled
+	if d.DeletionTimestamp != nil {
+		return reconcile.Result{}, nil
+	}
+
 	result, err := r.reconcile(ctx, d)
 	if err != nil {
 		klog.Errorf("Failed to reconcile MachineDeployment %q: %v", request.NamespacedName, err)

--- a/vendor/github.com/openshift/cluster-api/pkg/controller/machinedeployment/sync.go
+++ b/vendor/github.com/openshift/cluster-api/pkg/controller/machinedeployment/sync.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	apirand "k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -152,6 +153,11 @@ func (r *ReconcileMachineDeployment) getNewMachineSet(d *machinev1beta1.MachineD
 			Selector:        *newMSSelector,
 			Template:        newMSTemplate,
 		},
+	}
+
+	// Add foregroundDeletion finalizer to MachineSet if the MachineDeployment has it
+	if sets.NewString(d.Finalizers...).Has(metav1.FinalizerDeleteDependents) {
+		newMS.Finalizers = []string{metav1.FinalizerDeleteDependents}
 	}
 
 	allMSs := append(oldMSs, &newMS)

--- a/vendor/github.com/openshift/cluster-api/pkg/controller/machineset/controller.go
+++ b/vendor/github.com/openshift/cluster-api/pkg/controller/machineset/controller.go
@@ -158,6 +158,12 @@ func (r *ReconcileMachineSet) Reconcile(request reconcile.Request) (reconcile.Re
 		return reconcile.Result{}, err
 	}
 
+	// Ignore deleted MachineSets, this can happen when foregroundDeletion
+	// is enabled
+	if machineSet.DeletionTimestamp != nil {
+		return reconcile.Result{}, nil
+	}
+
 	result, err := r.reconcile(ctx, machineSet)
 	if err != nil {
 		klog.Errorf("Failed to reconcile MachineSet %q: %v", request.NamespacedName, err)


### PR DESCRIPTION
Set common machine fields so when a machine provisioned in AWS is listed through `oc get machines`
all additional printer colums are properly populated. E.g. region, zone, instance type.

During the provisioning stage:
```
NAME             STATE     TYPE        REGION      ZONE         AGE
master-machine   running   m4.xlarge   us-east-1   us-east-1a   38s
```
After an instance got provisioned:
```
NAME             STATE     TYPE        REGION      ZONE         AGE
master-machine   running   m4.xlarge   us-east-1   us-east-1a   40s
```
After a machine is requsted to be deleted:
```
NAME             STATE           TYPE        REGION      ZONE         AGE
master-machine   shutting-down   m4.xlarge   us-east-1   us-east-1a   24m
```
In order to properly display values from all the annotations,
one needs to update the machine CRD to have:
```yaml
spec:
  additionalPrinterColumns:
  - JSONPath: .metadata.annotations['machine\.openshift\.io/instance-state']
    description: State of the AWS instance
    name: State
    type: string
  - JSONPath: .metadata.labels['machine\.openshift\.io/instance-type']
    description: Type of instance
    name: Type
    type: string
  - JSONPath: .metadata.labels['machine\.openshift\.io/region']
    description: Region associated with machine
    name: Region
    type: string
  - JSONPath: .metadata.labels['machine\.openshift\.io/zone']
    description: Zone associated with machine
    name: Zone
    type: string
```
Be aware of all the dots being escaped.

```sh
$ oc get machines -n openshift-machine-api
NAME                                     STATE     TYPE        REGION      ZONE         AGE
jchaloup-kndjk-master-0                  running   m4.xlarge   us-east-1   us-east-1a   16m
jchaloup-kndjk-master-1                  running   m4.xlarge   us-east-1   us-east-1b   16m
jchaloup-kndjk-master-2                  running   m4.xlarge   us-east-1   us-east-1c   16m
jchaloup-kndjk-worker-us-east-1a-rz7fc   running   m4.large    us-east-1   us-east-1a   15m
jchaloup-kndjk-worker-us-east-1b-skcdp   running   m4.large    us-east-1   us-east-1b   15m
jchaloup-kndjk-worker-us-east-1c-x949n   running   m4.large    us-east-1   us-east-1c   15m
```

```sh    
$ oc get machines -n openshift-machine-api  -o wide
NAME                                     STATE     TYPE        REGION      ZONE         AGE       NODE                           PROVIDERID
jchaloup-kndjk-master-0                  running   m4.xlarge   us-east-1   us-east-1a   16m       ip-10-0-137-186.ec2.internal
jchaloup-kndjk-master-1                  running   m4.xlarge   us-east-1   us-east-1b   16m       ip-10-0-144-222.ec2.internal
jchaloup-kndjk-master-2                  running   m4.xlarge   us-east-1   us-east-1c   16m       ip-10-0-164-95.ec2.internal
jchaloup-kndjk-worker-us-east-1a-rz7fc   running   m4.large    us-east-1   us-east-1a   15m       ip-10-0-131-249.ec2.internal   aws:///us-east-1a/i-0d61da03d03bc6c51
jchaloup-kndjk-worker-us-east-1b-skcdp   running   m4.large    us-east-1   us-east-1b   15m       ip-10-0-149-207.ec2.internal   aws:///us-east-1b/i-0dbe5a1764fa55848
jchaloup-kndjk-worker-us-east-1c-x949n   running   m4.large    us-east-1   us-east-1c   15m       ip-10-0-160-10.ec2.internal    aws:///us-east-1c/i-09380f6badaad266e