### PR TITLE
[WIP]BZ 1732929: Fix eviction failure scenario

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -507,11 +507,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:b79de44700bc7fc32b4f898e283754fa027616f87074be1cf65a7be5a961cc85"
+  digest = "1:cdf4d8665620f7588f2edcc6cd88dcf5f9497f1dc4758eb49ace646e4d7c8f3d"
   name = "github.com/openshift/kubernetes-drain"
   packages = ["."]
   pruneopts = "T"
-  revision = "4b061affbd00bfc62036a5cd3a57493db6c94151"
+  revision = "d20a33f09dbf11716de3110d7759f384ba9ef7c3"
 
 [[projects]]
   digest = "1:b8fec16794e7d426d17af8c201367278369aee7ea1de19d6c1b701787e03df79"

--- a/vendor/github.com/openshift/kubernetes-drain/drain.go
+++ b/vendor/github.com/openshift/kubernetes-drain/drain.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	golog "github.com/go-log/log"
@@ -37,8 +38,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	typedappsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	typedextensionsv1beta1 "k8s.io/client-go/kubernetes/typed/extensions/v1beta1"
 	typedpolicyv1beta1 "k8s.io/client-go/kubernetes/typed/policy/v1beta1"
 )
 
@@ -238,8 +239,8 @@ func (o *DrainOptions) unreplicatedFilter(pod corev1.Pod) (bool, *warning, *fata
 }
 
 type DaemonSetFilterOptions struct {
-	client typedextensionsv1beta1.ExtensionsV1beta1Interface
-	force bool
+	client           typedappsv1.AppsV1Interface
+	force            bool
 	ignoreDaemonSets bool
 }
 
@@ -328,8 +329,8 @@ func getPodsForDeletion(client kubernetes.Interface, node *corev1.Node, options 
 	fs := podStatuses{}
 
 	daemonSetOptions := &DaemonSetFilterOptions{
-		client: client.ExtensionsV1beta1(),
-		force: options.Force,
+		client:           client.AppsV1(),
+		force:            options.Force,
 		ignoreDaemonSets: options.IgnoreDaemonsets,
 	}
 
@@ -412,9 +413,13 @@ func deleteOrEvictPods(client kubernetes.Interface, pods []corev1.Pod, options *
 
 func evictPods(client typedpolicyv1beta1.PolicyV1beta1Interface, pods []corev1.Pod, policyGroupVersion string, options *DrainOptions, getPodFn func(namespace, name string) (*corev1.Pod, error)) error {
 	returnCh := make(chan error, 1)
+	stopCh := make(chan struct{})
+	var wg sync.WaitGroup
 
 	for _, pod := range pods {
-		go func(pod corev1.Pod, returnCh chan error) {
+		wg.Add(1)
+		go func(pod corev1.Pod, returnCh chan error, stopCh chan struct{}) {
+			defer wg.Done()
 			var err error
 			for {
 				err = evictPod(client, pod, policyGroupVersion, options.GracePeriodSeconds)
@@ -424,8 +429,14 @@ func evictPods(client typedpolicyv1beta1.PolicyV1beta1Interface, pods []corev1.P
 					returnCh <- nil
 					return
 				} else if apierrors.IsTooManyRequests(err) {
-					logf(options.Logger, "error when evicting pod %q (will retry after 5s): %v", pod.Name, err)
-					time.Sleep(5 * time.Second)
+					select {
+					case <-stopCh:
+						logf(options.Logger, "Received channel close for pod %q. Returning!!!", pod.Name)
+						return
+					default:
+						logf(options.Logger, "error when evicting pod %q (will retry after 5s): %v", pod.Name, err)
+						time.Sleep(5 * time.Second)
+					}
 				} else {
 					returnCh <- fmt.Errorf("error when evicting pod %q: %v", pod.Name, err)
 					return
@@ -438,7 +449,7 @@ func evictPods(client typedpolicyv1beta1.PolicyV1beta1Interface, pods []corev1.P
 			} else {
 				returnCh <- fmt.Errorf("error when waiting for pod %q terminating: %v", pod.Name, err)
 			}
-		}(pod, returnCh)
+		}(pod, returnCh, stopCh)
 	}
 
 	doneCount := 0
@@ -461,9 +472,14 @@ func evictPods(client typedpolicyv1beta1.PolicyV1beta1Interface, pods []corev1.P
 				errors = append(errors, err)
 			}
 		case <-globalTimeoutCh:
+			logf(options.Logger, "Closing stopCh")
+			close(stopCh)
+			wg.Wait()
 			return fmt.Errorf("Drain did not complete within %v", globalTimeout)
 		}
 	}
+	close(stopCh)
+	wg.Wait()
 	return utilerrors.NewAggregate(errors)
 }
 


### PR DESCRIPTION
A goroutine is run for evicting each pod running on the node. If the eviction fails with error "too many requests", goroutine keeps creating eviction requests forever with a sleep of 5 sec. After global timeout, Drain() returns but the goroutine for the pods continues to create eviction requests.

machine controller gets error from the Drain() and then after waiting for 20 secs again invokes Drain(). Again goroutine for eviction of each pod gets created. And this way after each Drain() return and a wait of 20 secs, goroutines for making eviction requesting keep getting created.

This PR is ensuring that after global timeout, all the goroutines return before thr return of Drain()