### PR TITLE
Bug 1734193: Wire provider spec EBS volume Encrypted field into ec2.EbsBlockDevice.Encrypted field

### DIFF
--- a/pkg/actuators/machine/instances.go
+++ b/pkg/actuators/machine/instances.go
@@ -178,7 +178,7 @@ func getAMI(AMI providerconfigv1.AWSResourceReference, client awsclient.Client) 
 }
 
 func getBlockDeviceMappings(blockDeviceMappings []providerconfigv1.BlockDeviceMappingSpec, AMI string, client awsclient.Client) ([]*ec2.BlockDeviceMapping, error) {
-	if len(blockDeviceMappings) == 0 {
+	if len(blockDeviceMappings) == 0 || blockDeviceMappings[0].EBS == nil {
 		return []*ec2.BlockDeviceMapping{}, nil
 	}
 
@@ -205,6 +205,7 @@ func getBlockDeviceMappings(blockDeviceMappings []providerconfigv1.BlockDeviceMa
 		Ebs: &ec2.EbsBlockDevice{
 			VolumeSize: volumeSize,
 			VolumeType: volumeType,
+			Encrypted:  blockDeviceMappings[0].EBS.Encrypted,
 		},
 	}
 	if *volumeType == "io1" {


### PR DESCRIPTION
AWS actuator allows to specify encrypted root volumes for compute machines.
Though, it does not wire it to EBS definition which is passed to AWS ec2 service.
The provider should respect the setting and provision encrypted volumes when requested.

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1734193