### PR TITLE
Do not access machine variable that is nil

### DIFF
--- a/pkg/actuators/machine/actuator.go
+++ b/pkg/actuators/machine/actuator.go
@@ -124,8 +124,9 @@ func (a *Actuator) Create(context context.Context, cluster *clusterv1.Cluster, m
 	if err != nil {
 		return fmt.Errorf("%s: failed to update machine object with providerID: %v", machine.Name, err)
 	}
+	machine = updatedMachine
 
-	updatedMachine, err = a.setMachineCloudProviderSpecifics(updatedMachine, instance)
+	updatedMachine, err = a.setMachineCloudProviderSpecifics(machine, instance)
 	if err != nil {
 		return fmt.Errorf("%s: failed to set machine cloud provider specifics: %v", machine.Name, err)
 	}
@@ -464,10 +465,11 @@ func (a *Actuator) Update(context context.Context, cluster *clusterv1.Cluster, m
 
 	a.eventRecorder.Eventf(machine, corev1.EventTypeNormal, "Updated", "Updated machine %v", machine.Name)
 
-	machine, err = a.setMachineCloudProviderSpecifics(machine, newestInstance)
+	modMachine, err := a.setMachineCloudProviderSpecifics(machine, newestInstance)
 	if err != nil {
 		return fmt.Errorf("%s: failed to set machine cloud provider specifics: %v", machine.Name, err)
 	}
+	machine = modMachine
 
 	// We do not support making changes to pre-existing instances, just update status.
 	return a.updateStatus(machine, newestInstance)


### PR DESCRIPTION
Fixing `/go/src/sigs.k8s.io/cluster-api-provider-aws/pkg/actuators/machine/actuator.go:467`:

```
/go/src/sigs.k8s.io/cluster-api-provider-aws/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:76
/go/src/sigs.k8s.io/cluster-api-provider-aws/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:65
/go/src/sigs.k8s.io/cluster-api-provider-aws/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:51
/usr/local/go/src/runtime/panic.go:522
/usr/local/go/src/runtime/panic.go:82
/usr/local/go/src/runtime/signal_unix.go:390
/go/src/sigs.k8s.io/cluster-api-provider-aws/pkg/actuators/machine/actuator.go:467
/go/src/sigs.k8s.io/cluster-api-provider-aws/vendor/github.com/openshift/cluster-api/pkg/controller/machine/controller.go:251
/go/src/sigs.k8s.io/cluster-api-provider-aws/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:210
/go/src/sigs.k8s.io/cluster-api-provider-aws/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:158
/go/src/sigs.k8s.io/cluster-api-provider-aws/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152
/go/src/sigs.k8s.io/cluster-api-provider-aws/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153
/go/src/sigs.k8s.io/cluster-api-provider-aws/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88
/usr/local/go/src/runtime/asm_amd64.s:1337
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x1465f1d]
```

Found at the bottom of https://00e9e64bacbefc1b721eb8d0fa3fb5d0b0985969f95aaa2d86-apidata.googleusercontent.com/download/storage/v1/b/origin-ci-test/o/logs%2Frelease-openshift-origin-installer-e2e-aws-serial-4.2%2F3322%2Fartifacts%2Fe2e-aws-serial%2Fpods%2Fopenshift-machine-api_machine-api-controllers-6c4d7f866f-q477d_machine-controller_previous.log?qk=AD5uMEtVhtlWgL0XgdYGapZO1ynK4BRrBRkSK15gB8jFF4gwQZEPxJ8mASt2A8pJ7nLGBK52obvMzuFtuHk0dmc_k6vcsoq374LEkPMmmkfjcYeKoP3VVhXjpM3aWHftAnYG4MHUvVhydwgY8b3FPprOk-5CY-84xgWPXXQ8gKnowqPd-N0oCAbxRiZrCdR8rmjg4bJr_aByRA7qEFcWJk4o2ew3CUKNyGX5XrVLjiJvd6ZXGLWRNwiC9yDqILUtfxXe24xB979ZihOcfC4xbHozRHrAAHQ2I-gvkE9NHpy2bAlsiuUwA-CM3p4vC3qpdb85K3SJY1cDUN4rllTnBGsJBQjpYM4kIKWUPAHusoQEtc6ziEsyXRb3kqst1g13hvW2KVtOZGh037JhlC0l4_JzZc87WuC2HA_z3e8s2Xq9Ah2iXPDxlTOzMg2LlQHiMukKCKNsli6PZcfQD6eLwLMtC9RoRfAxLKkAMOpvLtiewazH3cmfFXSvrxwhMuA_dBeGLetfL77CGJNu-Wv3YDoIfD68lPR1W3nm3zaVdiCn76SiWx89NP4sbptowefGOdVGsGlzeslFsgau9bxbXo8dm39RI7WmtkfVEOKuHajCuEVmtw1MtFK9bTL6qwizmytyvwUNqxxw0QevulR10sMtTFH2y4Uj-EzGRGUHoADpNcGMcqkumsGj_Hy5X0bVQ4LSWm6JnlqrmQDi4RpsDSMggrp5EU55NU-qOXS6z49lkb2k9Cjg1ahu35rand6Crwfrg86NYnlXPgSgQ1EQJ2wlBgWhNJnIqz_jKb-APAez4-JK3KA7vd1lufltMZrL5PPgCaWodMXTtbcvF4uCajnsbxCIMVSBL4PHmH8W0edkJuhLsgpzzmSWCGdPsI9EEbhvJ2rblCa76tCBUUJ-hs2afvuTB2aiQA8oLJe8fdHDYBuby8bZK12LmNn_7AfUfFGEJEkrRecAcBnj-B8L9k_l3F2Ah-iSiUO9p2NrfN7iWWf95IH-CfYnfh5Wn520Un5KhI9fejNu