### PR TITLE
Run machine-api directly from cluster-api-actuator-pkg@release-4.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,13 +111,8 @@ k8s-e2e: ## Run k8s specific e2e test
 		-args -v 5 -logtostderr true
 
 .PHONY: test-e2e
-test-e2e: ## Run openshift specific e2e test
-	go test -timeout 60m \
-		-v ./vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e \
-		-kubeconfig $${KUBECONFIG:-~/.kube/config} \
-		-machine-api-namespace $${NAMESPACE:-openshift-machine-api} \
-		-ginkgo.v \
-		-args -v 5 -logtostderr true
+test-e2e: ## Run e2e tests
+	hack/e2e.sh
 
 
 .PHONY: lint

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -euo pipefail
+
+unset GOFLAGS
+tmp="$(mktemp -d)"
+
+mkdir -p "$tmp/src/github.com/openshift/cluster-api-actuator-pkg"
+
+git clone --single-branch --branch release-4.1 "https://github.com/openshift/cluster-api-actuator-pkg.git" "$tmp/src/github.com/openshift/cluster-api-actuator-pkg"
+exec make -C "$tmp/src/github.com/openshift/cluster-api-actuator-pkg" test-e2e GOPATH="$tmp"


### PR DESCRIPTION
To avoid any vendoring from cluster-api-actuator-pkg and to change ordering of tests so operator tests are ran as first to avoid loosing machine-controller logs.

Only machine-api test suite related. Has no impact on the customer. Not run in the production code.