### PR TITLE
UPSTREAM: <carry>: openshift: Add temporary patch to disable metrics in capi manager vendored

### DIFF
--- a/vendor/github.com/openshift/cluster-api/cmd/manager/main.go
+++ b/vendor/github.com/openshift/cluster-api/cmd/manager/main.go
@@ -50,6 +50,8 @@ func main() {
 	// Create a new Cmd to provide shared dependencies and start components
 	syncPeriod := 10 * time.Minute
 	mgr, err := manager.New(cfg, manager.Options{
+		// Disable metrics serving
+		MetricsBindAddress: "0",
 		SyncPeriod: &syncPeriod,
 		Namespace:  *watchNamespace,
 	})


### PR DESCRIPTION
openshift/machine-api-operator#403 should fix it but
To help to get CI green in addition in case 403 does not make it first