### PR TITLE
pkg/actuators/machine/utils: Drop running/pending comment from getInstances

### DIFF
--- a/pkg/actuators/machine/utils.go
+++ b/pkg/actuators/machine/utils.go
@@ -166,7 +166,6 @@ func getInstances(machine *machinev1.Machine, client awsclient.Client, instanceS
 		})
 	}
 
-	// Query instances with our machine's name, and in running/pending state.
 	request := &ec2.DescribeInstancesInput{
 		Filters: requestFilters,
 	}


### PR DESCRIPTION
This is not just running; see [`existingInstanceStates`][1].

[1]: https://github.com/openshift/cluster-api-provider-aws/blob/6814fc34f30a4c98d5edeb0a4ef73bbd03fa959b/pkg/actuators/machine/utils.go#L36-L46