### PR TITLE
pkg/actuators/machine/utils: Client-side state filtering in getInstanceByID and getInstances

### DIFF
--- a/pkg/actuators/machine/actuator_test.go
+++ b/pkg/actuators/machine/actuator_test.go
@@ -1229,7 +1229,7 @@ func TestGetMachineInstances(t *testing.T) {
 						clusterFilter(clusterID),
 					},
 				}).Return(
-					&ec2.DescribeInstancesOutput{},
+					stubDescribeInstancesOutput(imageID, instanceID, ec2.InstanceStateNameTerminated),
 					nil,
 				).Times(1).After(first)
 
@@ -1263,12 +1263,12 @@ func TestGetMachineInstances(t *testing.T) {
 				t.Errorf("Error creating Actuator: %v", err)
 			}
 
-			instance, err := actuator.getMachineInstances(nil, machineCopy)
+			instances, err := actuator.getMachineInstances(nil, machineCopy)
 			if err != nil {
 				t.Errorf("Unexpected error from getMachineInstances: %v", err)
 			}
-			if tc.exists != (instance != nil) {
-				t.Errorf("Expected instance exists: %t, got instance: %v", tc.exists, instance)
+			if tc.exists != (len(instances) > 0) {
+				t.Errorf("Expected instance exists: %t, got instances: %v", tc.exists, instances)
 			}
 		})
 	}

--- a/pkg/actuators/machine/actuator_test.go
+++ b/pkg/actuators/machine/actuator_test.go
@@ -169,7 +169,7 @@ func TestMachineEvents(t *testing.T) {
 
 			mockAWSClient.EXPECT().RunInstances(gomock.Any()).Return(stubReservation("ami-a9acbbd6", "i-02fcb933c5da7085c"), tc.runInstancesErr).AnyTimes()
 			if tc.describeInstancesOutput == nil {
-				mockAWSClient.EXPECT().DescribeInstances(gomock.Any()).Return(stubDescribeInstancesOutput("ami-a9acbbd6", "i-02fcb933c5da7085c"), tc.describeInstancesErr).AnyTimes()
+				mockAWSClient.EXPECT().DescribeInstances(gomock.Any()).Return(stubDescribeInstancesOutput("ami-a9acbbd6", "i-02fcb933c5da7085c", ec2.InstanceStateNameRunning), tc.describeInstancesErr).AnyTimes()
 			} else {
 				mockAWSClient.EXPECT().DescribeInstances(gomock.Any()).Return(tc.describeInstancesOutput, tc.describeInstancesErr).AnyTimes()
 			}
@@ -546,7 +546,7 @@ func TestActuator(t *testing.T) {
 			mockAWSClient.EXPECT().RunInstances(gomock.Any()).Return(stubReservation("ami-a9acbbd6", "i-02fcb933c5da7085c"), tc.runInstancesErr).AnyTimes()
 
 			if tc.describeInstancesOutput == nil {
-				mockAWSClient.EXPECT().DescribeInstances(gomock.Any()).Return(stubDescribeInstancesOutput("ami-a9acbbd6", "i-02fcb933c5da7085c"), tc.describeInstancesErr).AnyTimes()
+				mockAWSClient.EXPECT().DescribeInstances(gomock.Any()).Return(stubDescribeInstancesOutput("ami-a9acbbd6", "i-02fcb933c5da7085c", ec2.InstanceStateNameRunning), tc.describeInstancesErr).AnyTimes()
 			} else {
 				mockAWSClient.EXPECT().DescribeInstances(gomock.Any()).Return(tc.describeInstancesOutput, tc.describeInstancesErr).AnyTimes()
 			}
@@ -656,7 +656,7 @@ func TestAvailabilityZone(t *testing.T) {
 							ImageId:    aws.String("ami-a9acbbd6"),
 							InstanceId: aws.String("i-02fcb933c5da7085c"),
 							State: &ec2.InstanceState{
-								Name: aws.String("Running"),
+								Name: aws.String(ec2.InstanceStateNameRunning),
 							},
 							LaunchTime: aws.Time(time.Now()),
 							Placement: &ec2.Placement{
@@ -675,7 +675,7 @@ func TestAvailabilityZone(t *testing.T) {
 									ImageId:    aws.String("ami-a9acbbd6"),
 									InstanceId: aws.String("i-02fcb933c5da7085c"),
 									State: &ec2.InstanceState{
-										Name: aws.String("Running"),
+										Name: aws.String(ec2.InstanceStateNameRunning),
 										Code: aws.Int64(16),
 									},
 									LaunchTime: aws.Time(time.Now()),
@@ -804,7 +804,7 @@ func TestCreate(t *testing.T) {
 	mockAWSClient.EXPECT().DescribeSecurityGroups(gomock.Any()).Return(nil, fmt.Errorf("describeSecurityGroups error")).AnyTimes()
 	mockAWSClient.EXPECT().DescribeAvailabilityZones(gomock.Any()).Return(nil, fmt.Errorf("describeAvailabilityZones error")).AnyTimes()
 	mockAWSClient.EXPECT().DescribeImages(gomock.Any()).Return(nil, fmt.Errorf("describeImages error")).AnyTimes()
-	mockAWSClient.EXPECT().DescribeInstances(gomock.Any()).Return(stubDescribeInstancesOutput("ami-a9acbbd6", "i-02fcb933c5da7085c"), nil).AnyTimes()
+	mockAWSClient.EXPECT().DescribeInstances(gomock.Any()).Return(stubDescribeInstancesOutput("ami-a9acbbd6", "i-02fcb933c5da7085c", ec2.InstanceStateNameRunning), nil).AnyTimes()
 	mockAWSClient.EXPECT().TerminateInstances(gomock.Any()).Return(&ec2.TerminateInstancesOutput{}, nil).AnyTimes()
 	mockAWSClient.EXPECT().RunInstances(gomock.Any()).Return(stubReservation("ami-a9acbbd6", "i-02fcb933c5da7085c"), nil).AnyTimes()
 	mockAWSClient.EXPECT().RegisterInstancesWithLoadBalancer(gomock.Any()).Return(nil, nil).AnyTimes()
@@ -1175,7 +1175,7 @@ func TestGetMachineInstances(t *testing.T) {
 				}
 
 				mockAWSClient.EXPECT().DescribeInstances(request).Return(
-					stubDescribeInstancesOutput(imageID, instanceID),
+					stubDescribeInstancesOutput(imageID, instanceID, ec2.InstanceStateNameRunning),
 					nil,
 				).Times(1)
 
@@ -1196,7 +1196,7 @@ func TestGetMachineInstances(t *testing.T) {
 				}
 
 				mockAWSClient.EXPECT().DescribeInstances(request).Return(
-					stubDescribeInstancesOutput(imageID, instanceID),
+					stubDescribeInstancesOutput(imageID, instanceID, ec2.InstanceStateNameRunning),
 					nil,
 				).Times(1)
 
@@ -1217,7 +1217,7 @@ func TestGetMachineInstances(t *testing.T) {
 				}
 
 				mockAWSClient.EXPECT().DescribeInstances(request).Return(
-					stubTerminatedInstanceDescribeInstancesOutput(imageID, instanceID),
+					stubDescribeInstancesOutput(imageID, instanceID, ec2.InstanceStateNameTerminated),
 					nil,
 				).Times(1)
 
@@ -1233,7 +1233,7 @@ func TestGetMachineInstances(t *testing.T) {
 				}
 
 				mockAWSClient.EXPECT().DescribeInstances(request2).Return(
-					stubTerminatedInstanceDescribeInstancesOutput(imageID, instanceID),
+					stubDescribeInstancesOutput(imageID, instanceID, ec2.InstanceStateNameTerminated),
 					nil,
 				).Times(1)
 

--- a/pkg/actuators/machine/awsclient_test.go
+++ b/pkg/actuators/machine/awsclient_test.go
@@ -44,7 +44,7 @@ func TestAwsClient(t *testing.T) {
 								ImageId:    aws.String("ami-a9acbbd6"),
 								InstanceId: aws.String("i-02fcb933c5da7085c"),
 								State: &ec2.InstanceState{
-									Name: aws.String("Running"),
+									Name: aws.String(ec2.InstanceStateNameRunning),
 								},
 								LaunchTime:       aws.Time(time.Now()),
 								PublicDnsName:    aws.String(""),

--- a/pkg/actuators/machine/instances_test.go
+++ b/pkg/actuators/machine/instances_test.go
@@ -239,7 +239,7 @@ func TestRunningInstance(t *testing.T) {
 						ImageId:    aws.String("ami-a9acbbd6"),
 						InstanceId: aws.String("i-02fcb933c5da7085c"),
 						State: &ec2.InstanceState{
-							Name: aws.String("Running"),
+							Name: aws.String(ec2.InstanceStateNameRunning),
 						},
 						LaunchTime: aws.Time(time.Now()),
 					},

--- a/pkg/actuators/machine/stubs.go
+++ b/pkg/actuators/machine/stubs.go
@@ -273,7 +273,7 @@ func stubReservation(imageID, instanceID string) *ec2.Reservation {
 	}
 }
 
-func stubDescribeInstancesOutput(imageID, instanceID string) *ec2.DescribeInstancesOutput {
+func stubDescribeInstancesOutput(imageID, instanceID string, state string) *ec2.DescribeInstancesOutput {
 	return &ec2.DescribeInstancesOutput{
 		Reservations: []*ec2.Reservation{
 			{
@@ -282,27 +282,7 @@ func stubDescribeInstancesOutput(imageID, instanceID string) *ec2.DescribeInstan
 						ImageId:    aws.String(imageID),
 						InstanceId: aws.String(instanceID),
 						State: &ec2.InstanceState{
-							Name: aws.String("Running"),
-							Code: aws.Int64(16),
-						},
-						LaunchTime: aws.Time(time.Now()),
-					},
-				},
-			},
-		},
-	}
-}
-
-func stubTerminatedInstanceDescribeInstancesOutput(imageID, instanceID string) *ec2.DescribeInstancesOutput {
-	return &ec2.DescribeInstancesOutput{
-		Reservations: []*ec2.Reservation{
-			{
-				Instances: []*ec2.Instance{
-					{
-						ImageId:    aws.String(imageID),
-						InstanceId: aws.String(instanceID),
-						State: &ec2.InstanceState{
-							Name: aws.String(ec2.InstanceStateNameTerminated),
+							Name: aws.String(state),
 							Code: aws.Int64(16),
 						},
 						LaunchTime: aws.Time(time.Now()),

--- a/pkg/actuators/machine/stubs.go
+++ b/pkg/actuators/machine/stubs.go
@@ -180,7 +180,7 @@ func stubInstance(imageID, instanceID string) *ec2.Instance {
 		ImageId:    aws.String(imageID),
 		InstanceId: aws.String(instanceID),
 		State: &ec2.InstanceState{
-			Name: aws.String("Running"),
+			Name: aws.String(ec2.InstanceStateNameRunning),
 			Code: aws.Int64(16),
 		},
 		LaunchTime:       aws.Time(time.Now()),
@@ -261,7 +261,7 @@ func stubReservation(imageID, instanceID string) *ec2.Reservation {
 				ImageId:    aws.String(imageID),
 				InstanceId: aws.String(instanceID),
 				State: &ec2.InstanceState{
-					Name: aws.String("Running"),
+					Name: aws.String(ec2.InstanceStateNameRunning),
 					Code: aws.Int64(16),
 				},
 				LaunchTime: aws.Time(time.Now()),

--- a/pkg/client/fake/fake.go
+++ b/pkg/client/fake/fake.go
@@ -81,7 +81,7 @@ func (c *awsClient) DescribeInstances(input *ec2.DescribeInstancesInput) (*ec2.D
 						ImageId:    aws.String("ami-a9acbbd6"),
 						InstanceId: aws.String("i-02fcb933c5da7085c"),
 						State: &ec2.InstanceState{
-							Name: aws.String("Running"),
+							Name: aws.String(ec2.InstanceStateNameRunning),
 							Code: aws.Int64(16),
 						},
 						LaunchTime: aws.Time(time.Now()),


### PR DESCRIPTION
We're already using server-side ID filtering, which means we should only ever have a single matching instance come back.  By keeping the state filtering local, we can log more interesting stuff like:

    instance i-123 state terminated is not in running, pending, stopped, stopping, shutting-down

/assign @enxebre