### PR TITLE
Bug 1761882: pkg/actuators/machine/actuator: Eventual-consistency wait for machines

### DIFF
--- a/pkg/actuators/machine/actuator.go
+++ b/pkg/actuators/machine/actuator.go
@@ -432,6 +432,11 @@ func (a *Actuator) Update(context context.Context, cluster *clusterv1.Cluster, m
 	// Parent controller should prevent this from ever happening by calling Exists and then Create,
 	// but instance could be deleted between the two calls.
 	if existingLen == 0 {
+		if machine.Spec.ProviderID != nil && (machine.Status.LastUpdated == nil || machine.Status.LastUpdated.Add(requeueAfterSeconds*time.Second).After(time.Now())) {
+			glog.Infof("%s: Possible eventual-consistency discrepancy; returning an error to requeue", machine.Name)
+			return &clustererror.RequeueAfterError{RequeueAfter: requeueAfterSeconds * time.Second}
+		}
+
 		glog.Warningf("%s: attempted to update machine but no instances found", machine.Name)
 
 		a.handleMachineError(machine, mapierrors.UpdateMachine("no instance found, reason unknown"), updateEventAction)


### PR DESCRIPTION
[Avoid][1]:

```console
$ curl -s https://storage.googleapis.com/origin-ci-test/logs/release-openshift-openshift-ansible-e2e-aws-scaleup-rhel7-4.3/255/artifacts/e2e-aws-scaleup-rhel7/must-gather/registry-svc-ci-openshift-org-ci-op-b24mfpd6-stable-sha256-64c63eedf863406fbc6c7515026f909a7221472cf70283708fb7010dd5e6139e/namespaces/openshift-machine-api/pods/machine-api-controllers-785b4687bf-wspnd/machine-controller/machine-controller/logs/current.log | grep -B5 'ci-op-b24mfpd6-6df53-m62pz-worker-us-east-1a-centos-sl696: found 0 existing instances for machine'
2019-11-18T01:08:14.686879882Z I1118 01:08:14.686811       1 actuator.go:552] ci-op-b24mfpd6-6df53-m62pz-worker-us-east-1a-centos-sl696: Found instance by id: i-04e60273f38857eed
2019-11-18T01:08:14.686879882Z I1118 01:08:14.686839       1 actuator.go:502] ci-op-b24mfpd6-6df53-m62pz-worker-us-east-1a-centos-sl696: Instance exists as "i-04e60273f38857eed"
2019-11-18T01:08:14.686879882Z I1118 01:08:14.686853       1 controller.go:284] Reconciling machine "ci-op-b24mfpd6-6df53-m62pz-worker-us-east-1a-centos-sl696" triggers idempotent update
2019-11-18T01:08:14.686879882Z I1118 01:08:14.686862       1 actuator.go:406] ci-op-b24mfpd6-6df53-m62pz-worker-us-east-1a-centos-sl696: updating machine
2019-11-18T01:08:14.68696548Z I1118 01:08:14.686938       1 actuator.go:414] ci-op-b24mfpd6-6df53-m62pz-worker-us-east-1a-centos-sl696: obtaining EC2 client for region
2019-11-18T01:08:14.741237517Z I1118 01:08:14.741189       1 actuator.go:430] ci-op-b24mfpd6-6df53-m62pz-worker-us-east-1a-centos-sl696: found 0 existing instances for machine
```

by waiting a bit for AWS to resolve any [eventual-consistency issues][2] before giving up on a machine and claiming it failed.  With this commit, we'll try again until requeueAfterSeconds have passed since
the last status update or the phase transitions to something besides `Provisioning` or `Provisioned` (why doesn't the cluster API repository provide public constants for these?).  This doesn't address other transitions; there may be more eventual-consistency issues in the actuator, but we can address those narrowly as we find them.  Building a generic "are you sure, AWS?" re-trier seems like overkill at the moment.

The efficiency of the retry request is weakened a bit by the AWS provider / machine controller pairing [apparently ignoring requeue delays][3].  But even if that's the case, a busy loop here is still better than abandoning the machine.

/assign @enxebre

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1772163#c11
[2]: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/query-api-troubleshooting.html#eventual-consistency
[3]: https://bugzilla.redhat.com/show_bug.cgi?id=1772192


~Also revert openshift/cluster-api-provider-aws#270~ dropped after [this][4].

[4]: https://github.com/openshift/cluster-api-provider-aws/pull/271#discussion_r347829505