### PR TITLE
pkg/actuators/machine/actuator: Drop setMachineCloudProviderSpecifics comment

### DIFF
--- a/pkg/actuators/machine/actuator.go
+++ b/pkg/actuators/machine/actuator.go
@@ -130,7 +130,6 @@ func (a *Actuator) Create(context context.Context, cluster *clusterv1.Cluster, m
 	return a.updateStatus(updatedMachine, instance)
 }
 
-// updateProviderID adds providerID in the machine spec
 func (a *Actuator) setMachineCloudProviderSpecifics(machine *machinev1.Machine, instance *ec2.Instance) (*machinev1.Machine, error) {
 	if instance == nil {
 		return machine, nil


### PR DESCRIPTION
The `updateProviderID` comment was probably a copy/paste error when `setMachineCloudProviderSpecifics` landed in 716083f839 (#242).  I haven't read through the function carefully enough to be able to propose a comment that adds much beyond the function name, which is fairly clear on its own.  But I know the `updateProviderID` comment is not a good fit ;).