### PR TITLE
[release-4.3] Bug 1780590: Update Machine status with all instance IP addresses

### DIFF
--- a/pkg/actuators/machine/actuator.go
+++ b/pkg/actuators/machine/actuator.go
@@ -614,31 +614,16 @@ func (a *Actuator) updateStatus(machine *machinev1.Machine, instance *ec2.Instan
 	} else {
 		awsStatus.InstanceID = instance.InstanceId
 		awsStatus.InstanceState = instance.State.Name
-		if instance.PublicIpAddress != nil {
-			networkAddresses = append(networkAddresses, corev1.NodeAddress{
-				Type:    corev1.NodeExternalIP,
-				Address: *instance.PublicIpAddress,
-			})
+
+		addresses, err := extractNodeAddresses(instance)
+		if err != nil {
+			glog.Errorf("%s: Error extracting instance IP addresses: %v", machine.Name, err)
+			return err
 		}
-		if instance.PrivateIpAddress != nil {
-			networkAddresses = append(networkAddresses, corev1.NodeAddress{
-				Type:    corev1.NodeInternalIP,
-				Address: *instance.PrivateIpAddress,
-			})
-		}
-		if instance.PublicDnsName != nil {
-			networkAddresses = append(networkAddresses, corev1.NodeAddress{
-				Type:    corev1.NodeExternalDNS,
-				Address: *instance.PublicDnsName,
-			})
-		}
-		if instance.PrivateDnsName != nil {
-			networkAddresses = append(networkAddresses, corev1.NodeAddress{
-				Type:    corev1.NodeInternalDNS,
-				Address: *instance.PrivateDnsName,
-			})
-		}
+
+		networkAddresses = append(networkAddresses, addresses...)
 	}
+
 	glog.Infof("%s: finished calculating AWS status", machine.Name)
 
 	awsStatus.Conditions = setAWSMachineProviderCondition(awsStatus.Conditions, providerconfigv1.MachineCreation, corev1.ConditionTrue, MachineCreationSucceeded, "machine successfully created", updateConditionIfReasonOrMessageChange)

--- a/pkg/actuators/machine/utils_test.go
+++ b/pkg/actuators/machine/utils_test.go
@@ -4,8 +4,11 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	machinev1 "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	providerconfigv1 "sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1beta1"
@@ -84,5 +87,92 @@ func TestProviderConfigFromMachine(t *testing.T) {
 		if !reflect.DeepEqual(decodedProviderConfig, providerConfig) {
 			t.Errorf("Test case %s. Expected: %v, got: %v", tc.machine.Name, providerConfig, decodedProviderConfig)
 		}
+	}
+}
+
+func TestExtractNodeAddresses(t *testing.T) {
+	testCases := []struct {
+		testcase          string
+		instance          *ec2.Instance
+		expectedAddresses []corev1.NodeAddress
+	}{
+		{
+			testcase: "one-public",
+			instance: &ec2.Instance{
+				PublicIpAddress: aws.String("1.1.1.1"),
+				PublicDnsName:   aws.String("ec2.example.net"),
+			},
+			expectedAddresses: []corev1.NodeAddress{
+				{Type: corev1.NodeExternalIP, Address: "1.1.1.1"},
+				{Type: corev1.NodeExternalDNS, Address: "ec2.example.net"},
+			},
+		},
+		{
+			testcase: "one-private",
+			instance: &ec2.Instance{
+				PrivateDnsName: aws.String("ec2.example.net"),
+				NetworkInterfaces: []*ec2.InstanceNetworkInterface{
+					{
+						Status: aws.String(ec2.NetworkInterfaceStatusInUse),
+						PrivateIpAddresses: []*ec2.InstancePrivateIpAddress{
+							{
+								Primary:          aws.Bool(true),
+								PrivateIpAddress: aws.String("10.0.0.5"),
+							},
+						},
+					},
+				},
+			},
+			expectedAddresses: []corev1.NodeAddress{
+				{Type: corev1.NodeInternalIP, Address: "10.0.0.5"},
+				{Type: corev1.NodeInternalDNS, Address: "ec2.example.net"},
+				{Type: corev1.NodeHostName, Address: "ec2.example.net"},
+			},
+		},
+		{
+			testcase: "multiple-private",
+			instance: &ec2.Instance{
+				PrivateDnsName: aws.String("ec2.example.net"),
+				NetworkInterfaces: []*ec2.InstanceNetworkInterface{
+					{
+						Status: aws.String(ec2.NetworkInterfaceStatusInUse),
+						PrivateIpAddresses: []*ec2.InstancePrivateIpAddress{
+							{
+								Primary:          aws.Bool(true),
+								PrivateIpAddress: aws.String("10.0.0.5"),
+							},
+						},
+					},
+					{
+						Status: aws.String(ec2.NetworkInterfaceStatusInUse),
+						PrivateIpAddresses: []*ec2.InstancePrivateIpAddress{
+							{
+								Primary:          aws.Bool(false),
+								PrivateIpAddress: aws.String("10.0.0.6"),
+							},
+						},
+					},
+				},
+			},
+			expectedAddresses: []corev1.NodeAddress{
+				{Type: corev1.NodeInternalIP, Address: "10.0.0.5"},
+				{Type: corev1.NodeInternalIP, Address: "10.0.0.6"},
+				{Type: corev1.NodeInternalDNS, Address: "ec2.example.net"},
+				{Type: corev1.NodeHostName, Address: "ec2.example.net"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testcase, func(t *testing.T) {
+			addresses, err := extractNodeAddresses(tc.instance)
+			if err != nil {
+				t.Errorf("Unexpected extractNodeAddresses error: %v", err)
+			}
+
+			if !equality.Semantic.DeepEqual(addresses, tc.expectedAddresses) {
+				t.Errorf("expected: %v, got: %v", tc.expectedAddresses, addresses)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Previously we only updated the addresses in a Machine's status with
the primary public and private IP addresses and DNS names.  That
causes problems with automated CSR renewal because the Subject
Alternative Names in CSRs come from the addresses on the Node object,
which include all addresses, e.g. ones added by attaching additional
network interfaces after an instance is created.  This changes the
behavior to match what the Kubernetes AWS cloud provider does, which
is to include the addresses of all attached interfaces.