### PR TITLE
[release-4.2] Bug 1781160: Update Machine status with all instance IP addresses

### DIFF
--- a/pkg/actuators/machine/actuator.go
+++ b/pkg/actuators/machine/actuator.go
@@ -601,31 +601,16 @@ func (a *Actuator) updateStatus(machine *machinev1.Machine, instance *ec2.Instan
 	} else {
 		awsStatus.InstanceID = instance.InstanceId
 		awsStatus.InstanceState = instance.State.Name
-		if instance.PublicIpAddress != nil {
-			networkAddresses = append(networkAddresses, corev1.NodeAddress{
-				Type:    corev1.NodeExternalIP,
-				Address: *instance.PublicIpAddress,
-			})
+
+		addresses, err := extractNodeAddresses(instance)
+		if err != nil {
+			glog.Errorf("%s: Error extracting instance IP addresses: %v", machine.Name, err)
+			return err
 		}
-		if instance.PrivateIpAddress != nil {
-			networkAddresses = append(networkAddresses, corev1.NodeAddress{
-				Type:    corev1.NodeInternalIP,
-				Address: *instance.PrivateIpAddress,
-			})
-		}
-		if instance.PublicDnsName != nil {
-			networkAddresses = append(networkAddresses, corev1.NodeAddress{
-				Type:    corev1.NodeExternalDNS,
-				Address: *instance.PublicDnsName,
-			})
-		}
-		if instance.PrivateDnsName != nil {
-			networkAddresses = append(networkAddresses, corev1.NodeAddress{
-				Type:    corev1.NodeInternalDNS,
-				Address: *instance.PrivateDnsName,
-			})
-		}
+
+		networkAddresses = append(networkAddresses, addresses...)
 	}
+
 	glog.Infof("%s: finished calculating AWS status", machine.Name)
 
 	awsStatus.Conditions = setAWSMachineProviderCondition(awsStatus.Conditions, providerconfigv1.MachineCreation, corev1.ConditionTrue, MachineCreationSucceeded, "machine successfully created", updateConditionIfReasonOrMessageChange)

--- a/pkg/actuators/machine/utils.go
+++ b/pkg/actuators/machine/utils.go
@@ -18,6 +18,7 @@ package machine
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/golang/glog"
 
@@ -302,4 +303,56 @@ func findAWSMachineProviderCondition(conditions []providerconfigv1.AWSMachinePro
 		}
 	}
 	return nil
+}
+
+// extractNodeAddresses maps the instance information from EC2 to an array of NodeAddresses
+func extractNodeAddresses(instance *ec2.Instance) ([]corev1.NodeAddress, error) {
+	// Not clear if the order matters here, but we might as well indicate a sensible preference order
+
+	if instance == nil {
+		return nil, fmt.Errorf("nil instance passed to extractNodeAddresses")
+	}
+
+	addresses := []corev1.NodeAddress{}
+
+	// handle internal network interfaces
+	for _, networkInterface := range instance.NetworkInterfaces {
+		// skip network interfaces that are not currently in use
+		if aws.StringValue(networkInterface.Status) != ec2.NetworkInterfaceStatusInUse {
+			continue
+		}
+
+		for _, internalIP := range networkInterface.PrivateIpAddresses {
+			if ipAddress := aws.StringValue(internalIP.PrivateIpAddress); ipAddress != "" {
+				ip := net.ParseIP(ipAddress)
+				if ip == nil {
+					return nil, fmt.Errorf("EC2 instance had invalid private address: %s (%q)", aws.StringValue(instance.InstanceId), ipAddress)
+				}
+				addresses = append(addresses, corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: ip.String()})
+			}
+		}
+	}
+
+	// TODO: Other IP addresses (multiple ips)?
+	publicIPAddress := aws.StringValue(instance.PublicIpAddress)
+	if publicIPAddress != "" {
+		ip := net.ParseIP(publicIPAddress)
+		if ip == nil {
+			return nil, fmt.Errorf("EC2 instance had invalid public address: %s (%s)", aws.StringValue(instance.InstanceId), publicIPAddress)
+		}
+		addresses = append(addresses, corev1.NodeAddress{Type: corev1.NodeExternalIP, Address: ip.String()})
+	}
+
+	privateDNSName := aws.StringValue(instance.PrivateDnsName)
+	if privateDNSName != "" {
+		addresses = append(addresses, corev1.NodeAddress{Type: corev1.NodeInternalDNS, Address: privateDNSName})
+		addresses = append(addresses, corev1.NodeAddress{Type: corev1.NodeHostName, Address: privateDNSName})
+	}
+
+	publicDNSName := aws.StringValue(instance.PublicDnsName)
+	if publicDNSName != "" {
+		addresses = append(addresses, corev1.NodeAddress{Type: corev1.NodeExternalDNS, Address: publicDNSName})
+	}
+
+	return addresses, nil
 }

--- a/pkg/actuators/machine/utils_test.go
+++ b/pkg/actuators/machine/utils_test.go
@@ -5,7 +5,12 @@ import (
 	"testing"
 
 	machinev1 "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	providerconfigv1 "sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1beta1"
@@ -84,5 +89,92 @@ func TestProviderConfigFromMachine(t *testing.T) {
 		if !reflect.DeepEqual(decodedProviderConfig, providerConfig) {
 			t.Errorf("Test case %s. Expected: %v, got: %v", tc.machine.Name, providerConfig, decodedProviderConfig)
 		}
+	}
+}
+
+func TestExtractNodeAddresses(t *testing.T) {
+	testCases := []struct {
+		testcase          string
+		instance          *ec2.Instance
+		expectedAddresses []corev1.NodeAddress
+	}{
+		{
+			testcase: "one-public",
+			instance: &ec2.Instance{
+				PublicIpAddress: aws.String("1.1.1.1"),
+				PublicDnsName:   aws.String("ec2.example.net"),
+			},
+			expectedAddresses: []corev1.NodeAddress{
+				{Type: corev1.NodeExternalIP, Address: "1.1.1.1"},
+				{Type: corev1.NodeExternalDNS, Address: "ec2.example.net"},
+			},
+		},
+		{
+			testcase: "one-private",
+			instance: &ec2.Instance{
+				PrivateDnsName: aws.String("ec2.example.net"),
+				NetworkInterfaces: []*ec2.InstanceNetworkInterface{
+					{
+						Status: aws.String(ec2.NetworkInterfaceStatusInUse),
+						PrivateIpAddresses: []*ec2.InstancePrivateIpAddress{
+							{
+								Primary:          aws.Bool(true),
+								PrivateIpAddress: aws.String("10.0.0.5"),
+							},
+						},
+					},
+				},
+			},
+			expectedAddresses: []corev1.NodeAddress{
+				{Type: corev1.NodeInternalIP, Address: "10.0.0.5"},
+				{Type: corev1.NodeInternalDNS, Address: "ec2.example.net"},
+				{Type: corev1.NodeHostName, Address: "ec2.example.net"},
+			},
+		},
+		{
+			testcase: "multiple-private",
+			instance: &ec2.Instance{
+				PrivateDnsName: aws.String("ec2.example.net"),
+				NetworkInterfaces: []*ec2.InstanceNetworkInterface{
+					{
+						Status: aws.String(ec2.NetworkInterfaceStatusInUse),
+						PrivateIpAddresses: []*ec2.InstancePrivateIpAddress{
+							{
+								Primary:          aws.Bool(true),
+								PrivateIpAddress: aws.String("10.0.0.5"),
+							},
+						},
+					},
+					{
+						Status: aws.String(ec2.NetworkInterfaceStatusInUse),
+						PrivateIpAddresses: []*ec2.InstancePrivateIpAddress{
+							{
+								Primary:          aws.Bool(false),
+								PrivateIpAddress: aws.String("10.0.0.6"),
+							},
+						},
+					},
+				},
+			},
+			expectedAddresses: []corev1.NodeAddress{
+				{Type: corev1.NodeInternalIP, Address: "10.0.0.5"},
+				{Type: corev1.NodeInternalIP, Address: "10.0.0.6"},
+				{Type: corev1.NodeInternalDNS, Address: "ec2.example.net"},
+				{Type: corev1.NodeHostName, Address: "ec2.example.net"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testcase, func(t *testing.T) {
+			addresses, err := extractNodeAddresses(tc.instance)
+			if err != nil {
+				t.Errorf("Unexpected extractNodeAddresses error: %v", err)
+			}
+
+			if !equality.Semantic.DeepEqual(addresses, tc.expectedAddresses) {
+				t.Errorf("expected: %v, got: %v", tc.expectedAddresses, addresses)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Previously we only updated the addresses in a Machine's status with
the primary public and private IP addresses and DNS names.  That
causes problems with automated CSR renewal because the Subject
Alternative Names in CSRs come from the addresses on the Node object,
which include all addresses, e.g. ones added by attaching additional
network interfaces after an instance is created.  This changes the
behavior to match what the Kubernetes AWS cloud provider does, which
is to include the addresses of all attached interfaces.

Cherry-pick of:
https://github.com/openshift/cluster-api-provider-aws/pull/277
https://github.com/openshift/cluster-api-provider-aws/pull/278