### PR TITLE
Include IPv6 addresses in Machine status

### DIFF
--- a/pkg/actuators/machine/utils_test.go
+++ b/pkg/actuators/machine/utils_test.go
@@ -161,6 +161,34 @@ func TestExtractNodeAddresses(t *testing.T) {
 				{Type: corev1.NodeHostName, Address: "ec2.example.net"},
 			},
 		},
+		{
+			testcase: "ipv6-private",
+			instance: &ec2.Instance{
+				PrivateDnsName: aws.String("ec2.example.net"),
+				NetworkInterfaces: []*ec2.InstanceNetworkInterface{
+					{
+						Status: aws.String(ec2.NetworkInterfaceStatusInUse),
+						Ipv6Addresses: []*ec2.InstanceIpv6Address{
+							{
+								Ipv6Address: aws.String("2600:1f18:4254:5100:ef8a:7b65:7782:9248"),
+							},
+						},
+						PrivateIpAddresses: []*ec2.InstancePrivateIpAddress{
+							{
+								Primary:          aws.Bool(true),
+								PrivateIpAddress: aws.String("10.0.0.5"),
+							},
+						},
+					},
+				},
+			},
+			expectedAddresses: []corev1.NodeAddress{
+				{Type: corev1.NodeInternalIP, Address: "2600:1f18:4254:5100:ef8a:7b65:7782:9248"},
+				{Type: corev1.NodeInternalIP, Address: "10.0.0.5"},
+				{Type: corev1.NodeInternalDNS, Address: "ec2.example.net"},
+				{Type: corev1.NodeHostName, Address: "ec2.example.net"},
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This includes any IPv6 addresses associated with an instance's network
interfaces in the Machine object's status.  They are listed with type
NodeInternalIP to match what KNI is doing:

  https://github.com/openshift-kni/origin/commit/7db21c1