### PR TITLE
WIP: machineset annotator

### DIFF
--- a/pkg/actuators/machine/actuator.go
+++ b/pkg/actuators/machine/actuator.go
@@ -629,12 +629,14 @@ func (a *Actuator) GetInstanceTypeDetails(_ context.Context, ms *machinev1.Machi
 		return nil, a.handleMachineError(machine, apierrors.InvalidMachineConfiguration("error decoding MachineProviderConfig: %v", err), createEventAction)
 	}
 	if machineProviderConfig.CredentialsSecret != nil {
-		credentialsSecretName = machineProviderConfig.CredentialsSecret.Name
+		credentialsSecretName = machineProviderConfig.CredentialsSecret.Name + "-pricing"
 	}
 	var values map[string]string
-	awsSecrets, err := a.getSecret(credentialsSecretName, machineset.Namespace)
+	awsSecrets, err := a.getSecret(credentialsSecretName, ms.Namespace)
 	if err == nil {
 		values = pricing.Doit(awsSecrets, "p2.16xlarge")
+	} else {
+		fmt.Println("priciingxxx getSecret failed", err)
 	}
 	if values == nil {
 		values = map[string]string{

--- a/pkg/actuators/machine/actuator.go
+++ b/pkg/actuators/machine/actuator.go
@@ -36,6 +36,7 @@ import (
 	clustererror "github.com/openshift/cluster-api/pkg/controller/error"
 	apierrors "github.com/openshift/cluster-api/pkg/errors"
 	providerconfigv1 "sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1beta1"
+	pricing "sigs.k8s.io/cluster-api-provider-aws/pkg/actuator/machine/pricing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -107,9 +108,13 @@ func (a *Actuator) handleMachineError(machine *machinev1.Machine, err *apierrors
 }
 
 func (a *Actuator) GetInstanceTypeDetails(_ context.Context, _ *machinev1.MachineSet) (map[string]string, error) {
-	return map[string]string{
-	    "mgugino": "testing",
-	}, nil
+	values := pricing.doit("p2.16xlarge")
+	if values == nil {
+		values = map[string]string{
+			"mgugino": "nothing found"
+		}
+	}
+	return values, nil
 }
 
 // Create runs a new EC2 instance

--- a/pkg/actuators/machine/actuator.go
+++ b/pkg/actuators/machine/actuator.go
@@ -106,6 +106,12 @@ func (a *Actuator) handleMachineError(machine *machinev1.Machine, err *apierrors
 	return err
 }
 
+func (a *Actuator) GetInstanceTypeDetails(_ context.Context, _ *machinev1.MachineSet) (map[string]string, error) {
+	return map[string]string{
+	    "mgugino": "testing",
+	}, nil
+}
+
 // Create runs a new EC2 instance
 func (a *Actuator) Create(context context.Context, cluster *clusterv1.Cluster, machine *machinev1.Machine) error {
 	glog.Infof("%s: creating machine", machine.Name)

--- a/pkg/actuators/machine/actuator.go
+++ b/pkg/actuators/machine/actuator.go
@@ -36,7 +36,7 @@ import (
 	clustererror "github.com/openshift/cluster-api/pkg/controller/error"
 	apierrors "github.com/openshift/cluster-api/pkg/errors"
 	providerconfigv1 "sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1beta1"
-	pricing "sigs.k8s.io/cluster-api-provider-aws/pkg/actuator/machine/pricing"
+	pricing "sigs.k8s.io/cluster-api-provider-aws/pkg/actuators/machine/pricing/lib"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -108,10 +108,10 @@ func (a *Actuator) handleMachineError(machine *machinev1.Machine, err *apierrors
 }
 
 func (a *Actuator) GetInstanceTypeDetails(_ context.Context, _ *machinev1.MachineSet) (map[string]string, error) {
-	values := pricing.doit("p2.16xlarge")
+	values := pricing.Doit("p2.16xlarge")
 	if values == nil {
 		values = map[string]string{
-			"mgugino": "nothing found"
+			"mgugino": "nothing found",
 		}
 	}
 	return values, nil

--- a/pkg/actuators/machine/pricing/lib/pricing.go
+++ b/pkg/actuators/machine/pricing/lib/pricing.go
@@ -1,0 +1,102 @@
+package lib
+
+import "github.com/aws/aws-sdk-go/service/pricing"
+import "github.com/aws/aws-sdk-go/aws/session"
+import "github.com/aws/aws-sdk-go/aws/awserr"
+import "github.com/aws/aws-sdk-go/aws"
+import "fmt"
+//import "io/ioutil"
+// import "encoding/json"
+
+type awsAttribute map[string]string
+type awsProduct struct {
+    Attributes awsAttribute
+    ProductFamily string
+    Sku string
+}
+
+var (
+    attributesToReturn = []string{"gpu", "memory", "vcpu"}
+)
+
+func Doit(instanceType string) map[string]string {
+
+    // Specify profile for config and region for requests
+    sess := session.Must(session.NewSessionWithOptions(session.Options{
+         Config: aws.Config{Region: aws.String("us-east-1")},
+    }))
+    svc := pricing.New(sess)
+    input := &pricing.GetProductsInput{
+        ServiceCode: aws.String("AmazonEC2"),
+        Filters: []*pricing.Filter{
+            {
+                Field: aws.String("productFamily"),
+                Type:  aws.String("TERM_MATCH"),
+                Value: aws.String("Compute Instance"),
+            },
+            {
+                Field: aws.String("instanceType"),
+                Type:  aws.String("TERM_MATCH"),
+                Value: aws.String(instanceType),
+            },
+        },
+        FormatVersion: aws.String("aws_v1"),
+        MaxResults:    aws.Int64(1),
+    }
+
+    result, err := svc.GetProducts(input)
+    if err != nil {
+        if aerr, ok := err.(awserr.Error); ok {
+            switch aerr.Code() {
+            case pricing.ErrCodeInternalErrorException:
+                fmt.Println(pricing.ErrCodeInternalErrorException, aerr.Error())
+            case pricing.ErrCodeInvalidParameterException:
+                fmt.Println(pricing.ErrCodeInvalidParameterException, aerr.Error())
+            case pricing.ErrCodeNotFoundException:
+                fmt.Println(pricing.ErrCodeNotFoundException, aerr.Error())
+            case pricing.ErrCodeInvalidNextTokenException:
+                fmt.Println(pricing.ErrCodeInvalidNextTokenException, aerr.Error())
+            case pricing.ErrCodeExpiredNextTokenException:
+                fmt.Println(pricing.ErrCodeExpiredNextTokenException, aerr.Error())
+            default:
+                fmt.Println(aerr.Error())
+            }
+        } else {
+            // Print the error, cast err to awserr.Error to get the Code and
+            // Message from an error.
+            fmt.Println(err.Error())
+        }
+        return nil
+    }
+    product := result.PriceList[0]["product"]
+    s, ok := product.(map[string]interface{})
+    if ok {
+        a, ok2 := s["attributes"].(map[string]interface{})
+        if ok2 {
+            resMap := make(map[string]string)
+            for _, att := range attributesToReturn {
+                if val, ok := a[att]; ok {
+                    valString, ok := val.(string)
+                    if ok {
+                        resMap[att] = valString
+                    }
+                }
+            }
+            return resMap
+        }
+    }
+    return nil
+    // This is a little handier but probably much less efficient
+    /*
+    jsonString, _ := json.Marshal(product)
+
+    var p awsProduct
+    //var p2 awsProduct
+    if err := json.Unmarshal(jsonString, &p); err != nil {
+        fmt.Println(err)
+    }
+    fmt.Println(p.Attributes["gpu"])
+
+    */
+
+}

--- a/pkg/actuators/machine/pricing/lib/pricing.go
+++ b/pkg/actuators/machine/pricing/lib/pricing.go
@@ -4,6 +4,7 @@ import "github.com/aws/aws-sdk-go/service/pricing"
 import "github.com/aws/aws-sdk-go/aws/session"
 import "github.com/aws/aws-sdk-go/aws/awserr"
 import "github.com/aws/aws-sdk-go/aws"
+import "github.com/aws/aws-sdk-go/aws/credentials"
 import "fmt"
 //import "io/ioutil"
 // import "encoding/json"
@@ -15,15 +16,24 @@ type awsProduct struct {
     Sku string
 }
 
+type AwsCreds struct {
+	AccessKeyID string
+	SecretAccessKey string
+}
+
 var (
     attributesToReturn = []string{"gpu", "memory", "vcpu"}
 )
 
-func Doit(instanceType string) map[string]string {
-
+func Doit(creds *AwsCreds, instanceType string) map[string]string {
+    awsConfig := aws.Config{Region: aws.String("us-east-1")}
+    if creds != nil {
+        awsConfig.Credentials = credentials.NewStaticCredentials(
+            creds.AccessKeyID, creds.AccessKeyID, "")
+    }
     // Specify profile for config and region for requests
     sess := session.Must(session.NewSessionWithOptions(session.Options{
-         Config: aws.Config{Region: aws.String("us-east-1")},
+         Config: awsConfig,
     }))
     svc := pricing.New(sess)
     input := &pricing.GetProductsInput{

--- a/pkg/actuators/machine/pricing/main.go
+++ b/pkg/actuators/machine/pricing/main.go
@@ -5,8 +5,22 @@ import "github.com/aws/aws-sdk-go/aws/session"
 import "github.com/aws/aws-sdk-go/aws/awserr"
 import "github.com/aws/aws-sdk-go/aws"
 import "fmt"
+import "io/ioutil"
+import "encoding/json"
+
+type awsAttribute map[string]string
+type awsProduct struct {
+    Attributes awsAttribute
+    ProductFamily string
+    Sku string
+}
 
 func main() {
+    doit("p2.16xlarge")
+}
+
+func doit(instanceType string) map[string]string {
+
     // Specify profile for config and region for requests
     sess := session.Must(session.NewSessionWithOptions(session.Options{
          Config: aws.Config{Region: aws.String("us-east-1")},
@@ -23,7 +37,7 @@ func main() {
             {
                 Field: aws.String("instanceType"),
                 Type:  aws.String("TERM_MATCH"),
-                Value: aws.String("r4.8xlarge"),
+                Value: aws.String(instanceType),
             },
         },
         FormatVersion: aws.String("aws_v1"),
@@ -55,6 +69,25 @@ func main() {
         return
     }
     product := result.PriceList[0]["product"]
-    fmt.Println(product)
+    s, ok := product.(map[string]interface{})
+    if ok {
+        a, ok2 := s["attributes"].(map[string]interface{})
+        if ok2 {
+            fmt.Println(a["gpu"])
+        }
+    }
+    return nil
+    // This is a little handier but probably much less efficient
+    /*
+    jsonString, _ := json.Marshal(product)
+
+    var p awsProduct
+    //var p2 awsProduct
+    if err := json.Unmarshal(jsonString, &p); err != nil {
+        fmt.Println(err)
+    }
+    fmt.Println(p.Attributes["gpu"])
+
+    */
 
 }

--- a/pkg/actuators/machine/pricing/main.go
+++ b/pkg/actuators/machine/pricing/main.go
@@ -1,12 +1,9 @@
 package main
 
-import "github.com/aws/aws-sdk-go/service/pricing"
-import "github.com/aws/aws-sdk-go/aws/session"
-import "github.com/aws/aws-sdk-go/aws/awserr"
-import "github.com/aws/aws-sdk-go/aws"
+import "sigs.k8s.io/cluster-api-provider-aws/pkg/actuators/machine/pricing/lib"
 import "fmt"
-import "io/ioutil"
-import "encoding/json"
+//import "io/ioutil"
+// import "encoding/json"
 
 type awsAttribute map[string]string
 type awsProduct struct {
@@ -15,79 +12,11 @@ type awsProduct struct {
     Sku string
 }
 
+var (
+    attributesToReturn = []string{"gpu", "memory", "vcpu"}
+)
+
 func main() {
-    doit("p2.16xlarge")
-}
-
-func doit(instanceType string) map[string]string {
-
-    // Specify profile for config and region for requests
-    sess := session.Must(session.NewSessionWithOptions(session.Options{
-         Config: aws.Config{Region: aws.String("us-east-1")},
-    }))
-    svc := pricing.New(sess)
-    input := &pricing.GetProductsInput{
-        ServiceCode: aws.String("AmazonEC2"),
-        Filters: []*pricing.Filter{
-            {
-                Field: aws.String("productFamily"),
-                Type:  aws.String("TERM_MATCH"),
-                Value: aws.String("Compute Instance"),
-            },
-            {
-                Field: aws.String("instanceType"),
-                Type:  aws.String("TERM_MATCH"),
-                Value: aws.String(instanceType),
-            },
-        },
-        FormatVersion: aws.String("aws_v1"),
-        MaxResults:    aws.Int64(1),
-    }
-
-    result, err := svc.GetProducts(input)
-    if err != nil {
-        if aerr, ok := err.(awserr.Error); ok {
-            switch aerr.Code() {
-            case pricing.ErrCodeInternalErrorException:
-                fmt.Println(pricing.ErrCodeInternalErrorException, aerr.Error())
-            case pricing.ErrCodeInvalidParameterException:
-                fmt.Println(pricing.ErrCodeInvalidParameterException, aerr.Error())
-            case pricing.ErrCodeNotFoundException:
-                fmt.Println(pricing.ErrCodeNotFoundException, aerr.Error())
-            case pricing.ErrCodeInvalidNextTokenException:
-                fmt.Println(pricing.ErrCodeInvalidNextTokenException, aerr.Error())
-            case pricing.ErrCodeExpiredNextTokenException:
-                fmt.Println(pricing.ErrCodeExpiredNextTokenException, aerr.Error())
-            default:
-                fmt.Println(aerr.Error())
-            }
-        } else {
-            // Print the error, cast err to awserr.Error to get the Code and
-            // Message from an error.
-            fmt.Println(err.Error())
-        }
-        return
-    }
-    product := result.PriceList[0]["product"]
-    s, ok := product.(map[string]interface{})
-    if ok {
-        a, ok2 := s["attributes"].(map[string]interface{})
-        if ok2 {
-            fmt.Println(a["gpu"])
-        }
-    }
-    return nil
-    // This is a little handier but probably much less efficient
-    /*
-    jsonString, _ := json.Marshal(product)
-
-    var p awsProduct
-    //var p2 awsProduct
-    if err := json.Unmarshal(jsonString, &p); err != nil {
-        fmt.Println(err)
-    }
-    fmt.Println(p.Attributes["gpu"])
-
-    */
-
+    resMap := lib.Doit("p2.16xlarge")
+    fmt.Println(resMap)
 }

--- a/pkg/actuators/machine/pricing/main.go
+++ b/pkg/actuators/machine/pricing/main.go
@@ -17,6 +17,6 @@ var (
 )
 
 func main() {
-    resMap := lib.Doit("p2.16xlarge")
+    resMap := lib.Doit(nil, "p2.16xlarge")
     fmt.Println(resMap)
 }

--- a/pkg/actuators/machine/pricing/main.go
+++ b/pkg/actuators/machine/pricing/main.go
@@ -19,4 +19,6 @@ var (
 func main() {
     resMap := lib.Doit(nil, "p2.16xlarge")
     fmt.Println(resMap)
+
+    // lib.Doit2("p2.8xlarge")
 }

--- a/pkg/actuators/machine/pricing/main.go
+++ b/pkg/actuators/machine/pricing/main.go
@@ -1,0 +1,60 @@
+package main
+
+import "github.com/aws/aws-sdk-go/service/pricing"
+import "github.com/aws/aws-sdk-go/aws/session"
+import "github.com/aws/aws-sdk-go/aws/awserr"
+import "github.com/aws/aws-sdk-go/aws"
+import "fmt"
+
+func main() {
+    // Specify profile for config and region for requests
+    sess := session.Must(session.NewSessionWithOptions(session.Options{
+         Config: aws.Config{Region: aws.String("us-east-1")},
+    }))
+    svc := pricing.New(sess)
+    input := &pricing.GetProductsInput{
+        ServiceCode: aws.String("AmazonEC2"),
+        Filters: []*pricing.Filter{
+            {
+                Field: aws.String("productFamily"),
+                Type:  aws.String("TERM_MATCH"),
+                Value: aws.String("Compute Instance"),
+            },
+            {
+                Field: aws.String("instanceType"),
+                Type:  aws.String("TERM_MATCH"),
+                Value: aws.String("r4.8xlarge"),
+            },
+        },
+        FormatVersion: aws.String("aws_v1"),
+        MaxResults:    aws.Int64(1),
+    }
+
+    result, err := svc.GetProducts(input)
+    if err != nil {
+        if aerr, ok := err.(awserr.Error); ok {
+            switch aerr.Code() {
+            case pricing.ErrCodeInternalErrorException:
+                fmt.Println(pricing.ErrCodeInternalErrorException, aerr.Error())
+            case pricing.ErrCodeInvalidParameterException:
+                fmt.Println(pricing.ErrCodeInvalidParameterException, aerr.Error())
+            case pricing.ErrCodeNotFoundException:
+                fmt.Println(pricing.ErrCodeNotFoundException, aerr.Error())
+            case pricing.ErrCodeInvalidNextTokenException:
+                fmt.Println(pricing.ErrCodeInvalidNextTokenException, aerr.Error())
+            case pricing.ErrCodeExpiredNextTokenException:
+                fmt.Println(pricing.ErrCodeExpiredNextTokenException, aerr.Error())
+            default:
+                fmt.Println(aerr.Error())
+            }
+        } else {
+            // Print the error, cast err to awserr.Error to get the Code and
+            // Message from an error.
+            fmt.Println(err.Error())
+        }
+        return
+    }
+    product := result.PriceList[0]["product"]
+    fmt.Println(product)
+
+}

--- a/pkg/drain/drain.go
+++ b/pkg/drain/drain.go
@@ -1,0 +1,594 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package drain
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"time"
+
+	golog "github.com/go-log/log"
+
+	corev1 "k8s.io/api/core/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	typedappsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
+	typedpolicyv1beta1 "k8s.io/client-go/kubernetes/typed/policy/v1beta1"
+)
+
+type DrainOptions struct {
+	// Continue even if there are pods not managed by a ReplicationController, ReplicaSet, Job, DaemonSet or StatefulSet.
+	Force bool
+
+	// Ignore DaemonSet-managed pods.
+	IgnoreDaemonsets bool
+
+	// Period of time in seconds given to each pod to terminate
+	// gracefully.  If negative, the default value specified in the pod
+	// will be used.
+	GracePeriodSeconds int
+
+	// The length of time to wait before giving up on deletion or
+	// eviction.  Zero means infinite.
+	Timeout time.Duration
+
+	// Continue even if there are pods using emptyDir (local data that
+	// will be deleted when the node is drained).
+	DeleteLocalData bool
+
+	// Namespace to filter pods on the node.
+	Namespace string
+
+	// Label selector to filter pods on the node.
+	Selector labels.Selector
+
+	// Logger allows callers to plug in their preferred logger.
+	Logger golog.Logger
+}
+
+// Takes a pod and returns a bool indicating whether or not to operate on the
+// pod, an optional warning message, and an optional fatal error.
+type podFilter func(corev1.Pod) (include bool, w *warning, f *fatal)
+type warning struct {
+	string
+}
+type fatal struct {
+	string
+}
+
+const (
+	EvictionKind        = "Eviction"
+	EvictionSubresource = "pods/eviction"
+
+	kDaemonsetFatal      = "DaemonSet-managed pods (use IgnoreDaemonsets to ignore)"
+	kDaemonsetWarning    = "ignoring DaemonSet-managed pods"
+	kLocalStorageFatal   = "pods with local storage (use DeleteLocalData to override)"
+	kLocalStorageWarning = "deleting pods with local storage"
+	kUnmanagedFatal      = "pods not managed by ReplicationController, ReplicaSet, Job, DaemonSet or StatefulSet (use Force to override)"
+	kUnmanagedWarning    = "deleting pods not managed by ReplicationController, ReplicaSet, Job, DaemonSet or StatefulSet"
+)
+
+// GetNodes looks up the nodes (either given by name as arguments or
+// by the Selector option).
+func GetNodes(client typedcorev1.NodeInterface, nodes []string, selector string) (out []*corev1.Node, err error) {
+	if len(nodes) == 0 && len(selector) == 0 {
+		return nil, nil
+	}
+
+	if len(selector) > 0 && len(nodes) > 0 {
+		return nil, errors.New("cannot specify both node names and a selector option")
+	}
+
+	out = []*corev1.Node{}
+
+	for _, node := range nodes {
+		node, err := client.Get(node, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, node)
+	}
+
+	if len(selector) > 0 {
+		nodes, err := client.List(metav1.ListOptions{
+			LabelSelector: selector,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, node := range nodes.Items {
+			out = append(out, &node)
+		}
+	}
+
+	return out, nil
+}
+
+// Drain nodes in preparation for maintenance.
+//
+// The given nodes will be marked unschedulable to prevent new pods from arriving.
+// Drain evicts the pods if the APIServer supports eviction
+// (http://kubernetes.io/docs/admin/disruptions/). Otherwise, it will use normal DELETE
+// to delete the pods.
+// Drain evicts or deletes all pods except mirror pods (which cannot be deleted through
+// the API server).  If there are DaemonSet-managed pods, Drain will not proceed
+// without IgnoreDaemonsets, and regardless it will not delete any
+// DaemonSet-managed pods, because those pods would be immediately replaced by the
+// DaemonSet controller, which ignores unschedulable markings.  If there are any
+// pods that are neither mirror pods nor managed by ReplicationController,
+// ReplicaSet, DaemonSet, StatefulSet or Job, then Drain will not delete any pods unless you
+// use Force.  Force will also allow deletion to proceed if the managing resource of one
+// or more pods is missing.
+//
+// Drain waits for graceful termination. You should not operate on the machine until
+// the command completes.
+//
+// When you are ready to put the nodes back into service, use Uncordon, which
+// will make the nodes schedulable again.
+//
+// ![Workflow](http://kubernetes.io/images/docs/kubectl_drain.svg)
+func Drain(client kubernetes.Interface, nodes []*corev1.Node, options *DrainOptions) (err error) {
+	nodeInterface := client.CoreV1().Nodes()
+	for _, node := range nodes {
+		if err := Cordon(nodeInterface, node, options.Logger); err != nil {
+			return err
+		}
+	}
+
+	drainedNodes := sets.NewString()
+	var fatal error
+
+	for _, node := range nodes {
+		err := DeleteOrEvictPods(client, node, options)
+		if err == nil {
+			drainedNodes.Insert(node.Name)
+			logf(options.Logger, "drained node %q", node.Name)
+		} else {
+			log(options.Logger, err)
+			logf(options.Logger, "unable to drain node %q", node.Name)
+			remainingNodes := []string{}
+			fatal = err
+			for _, remainingNode := range nodes {
+				if drainedNodes.Has(remainingNode.Name) {
+					continue
+				}
+				remainingNodes = append(remainingNodes, remainingNode.Name)
+			}
+
+			if len(remainingNodes) > 0 {
+				sort.Strings(remainingNodes)
+				logf(options.Logger, "there are pending nodes to be drained: %s", strings.Join(remainingNodes, ","))
+			}
+		}
+	}
+
+	return fatal
+}
+
+// DeleteOrEvictPods deletes or (where supported) evicts pods from the
+// target node and waits until the deletion/eviction completes,
+// Timeout elapses, or an error occurs.
+func DeleteOrEvictPods(client kubernetes.Interface, node *corev1.Node, options *DrainOptions) error {
+	pods, err := getPodsForDeletion(client, node, options)
+	if err != nil {
+		return err
+	}
+
+	err = deleteOrEvictPods(client, pods, options)
+	if err != nil {
+		pendingPods, newErr := getPodsForDeletion(client, node, options)
+		if newErr != nil {
+			return newErr
+		}
+		pendingNames := make([]string, len(pendingPods))
+		for i, pendingPod := range pendingPods {
+			pendingNames[i] = pendingPod.Name
+		}
+		sort.Strings(pendingNames)
+		logf(options.Logger, "failed to evict pods from node %q (pending pods: %s): %v", node.Name, strings.Join(pendingNames, ","), err)
+	}
+	return err
+}
+
+func getPodController(pod corev1.Pod) *metav1.OwnerReference {
+	return metav1.GetControllerOf(&pod)
+}
+
+func (o *DrainOptions) unreplicatedFilter(pod corev1.Pod) (bool, *warning, *fatal) {
+	// any finished pod can be removed
+	if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+		return true, nil, nil
+	}
+
+	controllerRef := getPodController(pod)
+	if controllerRef != nil {
+		return true, nil, nil
+	}
+	if o.Force {
+		return true, &warning{kUnmanagedWarning}, nil
+	}
+
+	return false, nil, &fatal{kUnmanagedFatal}
+}
+
+type DaemonSetFilterOptions struct {
+	client typedappsv1.AppsV1Interface
+	force bool
+	ignoreDaemonSets bool
+}
+
+func (o *DaemonSetFilterOptions) daemonSetFilter(pod corev1.Pod) (bool, *warning, *fatal) {
+	// Note that we return false in cases where the pod is DaemonSet managed,
+	// regardless of flags.  We never delete them, the only question is whether
+	// their presence constitutes an error.
+	//
+	// The exception is for pods that are orphaned (the referencing
+	// management resource - including DaemonSet - is not found).
+	// Such pods will be deleted if Force is used.
+	controllerRef := getPodController(pod)
+	if controllerRef == nil || controllerRef.Kind != "DaemonSet" {
+		return true, nil, nil
+	}
+
+	if _, err := o.client.DaemonSets(pod.Namespace).Get(controllerRef.Name, metav1.GetOptions{}); err != nil {
+		// remove orphaned pods with a warning if Force is used
+		if apierrors.IsNotFound(err) && o.force {
+			return true, &warning{err.Error()}, nil
+		}
+		return false, nil, &fatal{err.Error()}
+	}
+
+	if !o.ignoreDaemonSets {
+		return false, nil, &fatal{kDaemonsetFatal}
+	}
+
+	return false, &warning{kDaemonsetWarning}, nil
+}
+
+func mirrorPodFilter(pod corev1.Pod) (bool, *warning, *fatal) {
+	if _, found := pod.ObjectMeta.Annotations[corev1.MirrorPodAnnotationKey]; found {
+		return false, nil, nil
+	}
+	return true, nil, nil
+}
+
+func hasLocalStorage(pod corev1.Pod) bool {
+	for _, volume := range pod.Spec.Volumes {
+		if volume.EmptyDir != nil {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (o *DrainOptions) localStorageFilter(pod corev1.Pod) (bool, *warning, *fatal) {
+	if !hasLocalStorage(pod) {
+		return true, nil, nil
+	}
+	if !o.DeleteLocalData {
+		return false, nil, &fatal{kLocalStorageFatal}
+	}
+	return true, &warning{kLocalStorageWarning}, nil
+}
+
+// Map of status message to a list of pod names having that status.
+type podStatuses map[string][]string
+
+func (ps podStatuses) message() string {
+	msgs := []string{}
+
+	for key, pods := range ps {
+		msgs = append(msgs, fmt.Sprintf("%s: %s", key, strings.Join(pods, ", ")))
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// getPodsForDeletion receives resource info for a node, and returns all the pods from the given node that we
+// are planning on deleting. If there are any pods preventing us from deleting, we return that list in an error.
+func getPodsForDeletion(client kubernetes.Interface, node *corev1.Node, options *DrainOptions) (pods []corev1.Pod, err error) {
+	listOptions := metav1.ListOptions{
+		FieldSelector: fields.SelectorFromSet(fields.Set{"spec.nodeName": node.Name}).String(),
+	}
+	if options.Selector != nil {
+		listOptions.LabelSelector = options.Selector.String()
+	}
+	podList, err := client.CoreV1().Pods(options.Namespace).List(listOptions)
+	if err != nil {
+		return pods, err
+	}
+
+	ws := podStatuses{}
+	fs := podStatuses{}
+
+	daemonSetOptions := &DaemonSetFilterOptions{
+		client: client.AppsV1(),
+		force: options.Force,
+		ignoreDaemonSets: options.IgnoreDaemonsets,
+	}
+
+	for _, pod := range podList.Items {
+		podOk := true
+		for _, filt := range []podFilter{daemonSetOptions.daemonSetFilter, mirrorPodFilter, options.localStorageFilter, options.unreplicatedFilter} {
+			filterOk, w, f := filt(pod)
+
+			podOk = podOk && filterOk
+			if w != nil {
+				ws[w.string] = append(ws[w.string], pod.Name)
+			}
+			if f != nil {
+				fs[f.string] = append(fs[f.string], pod.Name)
+			}
+
+			// short-circuit as soon as pod not ok
+			// at that point, there is no reason to run pod
+			// through any additional filters
+			if !podOk {
+				break
+			}
+		}
+		if podOk {
+			pods = append(pods, pod)
+		}
+	}
+
+	if len(fs) > 0 {
+		return []corev1.Pod{}, errors.New(fs.message())
+	}
+	if len(ws) > 0 {
+		log(options.Logger, ws.message())
+	}
+	return pods, nil
+}
+
+func evictPod(client typedpolicyv1beta1.PolicyV1beta1Interface, pod corev1.Pod, policyGroupVersion string, gracePeriodSeconds int) error {
+	deleteOptions := &metav1.DeleteOptions{}
+	if gracePeriodSeconds >= 0 {
+		gracePeriod := int64(gracePeriodSeconds)
+		deleteOptions.GracePeriodSeconds = &gracePeriod
+	}
+	eviction := &policyv1beta1.Eviction{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: policyGroupVersion,
+			Kind:       EvictionKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pod.Name,
+			Namespace: pod.Namespace,
+		},
+		DeleteOptions: deleteOptions,
+	}
+	return client.Evictions(eviction.Namespace).Evict(eviction)
+}
+
+// deleteOrEvictPods deletes or evicts the pods on the api server
+func deleteOrEvictPods(client kubernetes.Interface, pods []corev1.Pod, options *DrainOptions) error {
+	if len(pods) == 0 {
+		return nil
+	}
+
+	policyGroupVersion, err := SupportEviction(client)
+	if err != nil {
+		return err
+	}
+
+	getPodFn := func(namespace, name string) (*corev1.Pod, error) {
+		return client.CoreV1().Pods(namespace).Get(name, metav1.GetOptions{})
+	}
+
+	if len(policyGroupVersion) > 0 {
+		// Remember to change change the URL manipulation func when Evction's version change
+		return evictPods(client.PolicyV1beta1(), pods, policyGroupVersion, options, getPodFn)
+	} else {
+		return deletePods(client.CoreV1(), pods, options, getPodFn)
+	}
+}
+
+func evictPods(client typedpolicyv1beta1.PolicyV1beta1Interface, pods []corev1.Pod, policyGroupVersion string, options *DrainOptions, getPodFn func(namespace, name string) (*corev1.Pod, error)) error {
+	returnCh := make(chan error, 1)
+
+	for _, pod := range pods {
+		go func(pod corev1.Pod, returnCh chan error) {
+			var err error
+			for {
+				err = evictPod(client, pod, policyGroupVersion, options.GracePeriodSeconds)
+				if err == nil {
+					break
+				} else if apierrors.IsNotFound(err) {
+					returnCh <- nil
+					return
+				} else if apierrors.IsTooManyRequests(err) {
+					logf(options.Logger, "error when evicting pod %q (will retry after 5s): %v", pod.Name, err)
+					time.Sleep(5 * time.Second)
+				} else {
+					returnCh <- fmt.Errorf("error when evicting pod %q: %v", pod.Name, err)
+					return
+				}
+			}
+			podArray := []corev1.Pod{pod}
+			_, err = waitForDelete(podArray, 1*time.Second, time.Duration(math.MaxInt64), true, options.Logger, getPodFn)
+			if err == nil {
+				returnCh <- nil
+			} else {
+				returnCh <- fmt.Errorf("error when waiting for pod %q terminating: %v", pod.Name, err)
+			}
+		}(pod, returnCh)
+	}
+
+	doneCount := 0
+	var errors []error
+
+	// 0 timeout means infinite, we use MaxInt64 to represent it.
+	var globalTimeout time.Duration
+	if options.Timeout == 0 {
+		globalTimeout = time.Duration(math.MaxInt64)
+	} else {
+		globalTimeout = options.Timeout
+	}
+	globalTimeoutCh := time.After(globalTimeout)
+	numPods := len(pods)
+	for doneCount < numPods {
+		select {
+		case err := <-returnCh:
+			doneCount++
+			if err != nil {
+				errors = append(errors, err)
+			}
+		case <-globalTimeoutCh:
+			return fmt.Errorf("Drain did not complete within %v", globalTimeout)
+		}
+	}
+	return utilerrors.NewAggregate(errors)
+}
+
+func deletePods(client typedcorev1.CoreV1Interface, pods []corev1.Pod, options *DrainOptions, getPodFn func(namespace, name string) (*corev1.Pod, error)) error {
+	// 0 timeout means infinite, we use MaxInt64 to represent it.
+	var globalTimeout time.Duration
+	if options.Timeout == 0 {
+		globalTimeout = time.Duration(math.MaxInt64)
+	} else {
+		globalTimeout = options.Timeout
+	}
+	deleteOptions := &metav1.DeleteOptions{}
+	if options.GracePeriodSeconds >= 0 {
+		gracePeriodSeconds := int64(options.GracePeriodSeconds)
+		deleteOptions.GracePeriodSeconds = &gracePeriodSeconds
+	}
+	for _, pod := range pods {
+		err := client.Pods(pod.Namespace).Delete(pod.Name, deleteOptions)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+	_, err := waitForDelete(pods, 1*time.Second, globalTimeout, false, options.Logger, getPodFn)
+	return err
+}
+
+func waitForDelete(pods []corev1.Pod, interval, timeout time.Duration, usingEviction bool, logger golog.Logger, getPodFn func(string, string) (*corev1.Pod, error)) ([]corev1.Pod, error) {
+	var verbStr string
+	if usingEviction {
+		verbStr = "evicted"
+	} else {
+		verbStr = "deleted"
+	}
+
+	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
+		pendingPods := []corev1.Pod{}
+		for i, pod := range pods {
+			p, err := getPodFn(pod.Namespace, pod.Name)
+			if apierrors.IsNotFound(err) || (p != nil && p.ObjectMeta.UID != pod.ObjectMeta.UID) {
+				logf(logger, "pod %q removed (%s)", pod.Name, verbStr)
+				continue
+			} else if err != nil {
+				return false, err
+			} else {
+				pendingPods = append(pendingPods, pods[i])
+			}
+		}
+		pods = pendingPods
+		if len(pendingPods) > 0 {
+			return false, nil
+		}
+		return true, nil
+	})
+	return pods, err
+}
+
+// SupportEviction uses Discovery API to find out if the server
+// supports the eviction subresource.  If supported, it will return
+// its groupVersion; otherwise it will return an empty string.
+func SupportEviction(clientset kubernetes.Interface) (string, error) {
+	discoveryClient := clientset.Discovery()
+	groupList, err := discoveryClient.ServerGroups()
+	if err != nil {
+		return "", err
+	}
+	foundPolicyGroup := false
+	var policyGroupVersion string
+	for _, group := range groupList.Groups {
+		if group.Name == "policy" {
+			foundPolicyGroup = true
+			policyGroupVersion = group.PreferredVersion.GroupVersion
+			break
+		}
+	}
+	if !foundPolicyGroup {
+		return "", nil
+	}
+	resourceList, err := discoveryClient.ServerResourcesForGroupVersion("v1")
+	if err != nil {
+		return "", err
+	}
+	for _, resource := range resourceList.APIResources {
+		if resource.Name == EvictionSubresource && resource.Kind == EvictionKind {
+			return policyGroupVersion, nil
+		}
+	}
+	return "", nil
+}
+
+// Cordon marks a node "Unschedulable".  This method is idempotent.
+func Cordon(client typedcorev1.NodeInterface, node *corev1.Node, logger golog.Logger) error {
+	return cordonOrUncordon(client, node, logger, true)
+}
+
+// Uncordon marks a node "Schedulable".  This method is idempotent.
+func Uncordon(client typedcorev1.NodeInterface, node *corev1.Node, logger golog.Logger) error {
+	return cordonOrUncordon(client, node, logger, false)
+}
+
+func cordonOrUncordon(client typedcorev1.NodeInterface, node *corev1.Node, logger golog.Logger, desired bool) error {
+	unsched := node.Spec.Unschedulable
+	if unsched == desired {
+		return nil
+	}
+
+	patch := []byte(fmt.Sprintf("{\"spec\":{\"unschedulable\":%t}}", desired))
+	_, err := client.Patch(node.Name, types.StrategicMergePatchType, patch)
+	if err == nil {
+		verbStr := "cordoned"
+		if !desired {
+			verbStr = "un" + verbStr
+		}
+		logf(logger, "%s node %q", verbStr, node.Name)
+	}
+	return err
+}
+
+func log(logger golog.Logger, v ...interface{}) {
+	if logger != nil {
+		logger.Log(v...)
+	}
+}
+
+func logf(logger golog.Logger, format string, v ...interface{}) {
+	if logger != nil {
+		logger.Logf(format, v...)
+	}
+}

--- a/pkg/drain/drain_test.go
+++ b/pkg/drain/drain_test.go
@@ -1,0 +1,768 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package drain
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"regexp"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/go-log/log/capture"
+
+	batch "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	extensions "k8s.io/api/extensions/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/klog"
+)
+
+func boolptr(b bool) *bool { return &b }
+
+func TestCordon(t *testing.T) {
+	_ = klog.Writer{LogFunc: klog.Info}
+	tests := []struct {
+		description           string
+		node                  string
+		schedulable           bool
+		cordon                bool
+		expectedGetNodesError string
+	}{
+		{
+			description: "uncordon for real",
+			node:        "node",
+			schedulable: false,
+			cordon:      false,
+		},
+		{
+			description: "uncordon does nothing",
+			node:        "node",
+			schedulable: true,
+			cordon:      false,
+		},
+		{
+			description: "cordon does nothing",
+			node:        "node",
+			schedulable: false,
+			cordon:      true,
+		},
+		{
+			description: "cordon for real",
+			node:        "node",
+			schedulable: true,
+			cordon:      true,
+		},
+		{
+			description:           "cordon missing node",
+			node:                  "bar",
+			schedulable:           true,
+			cordon:                true,
+			expectedGetNodesError: "^nodes \"bar\" not found$",
+		},
+		{
+			description:           "uncordon missing node",
+			node:                  "bar",
+			cordon:                false,
+			expectedGetNodesError: "^nodes \"bar\" not found$",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			client := fake.NewSimpleClientset(&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "node",
+					CreationTimestamp: metav1.Time{Time: time.Now()},
+				},
+				Status: corev1.NodeStatus{},
+				Spec: corev1.NodeSpec{
+					Unschedulable: !test.schedulable,
+				},
+			}).CoreV1().Nodes()
+
+			nodes, err := GetNodes(client, []string{test.node}, "")
+			if err != nil {
+				if len(test.expectedGetNodesError) == 0 {
+					t.Fatal(err)
+				} else if !regexp.MustCompile(test.expectedGetNodesError).MatchString(err.Error()) {
+					t.Fatalf("%q does not match %q", err.Error(), test.expectedGetNodesError)
+				}
+				return
+			} else if len(test.expectedGetNodesError) > 0 {
+				t.Fatalf("expected error %q", test.expectedGetNodesError)
+			}
+
+			node := nodes[0]
+
+			if test.cordon {
+				err = Cordon(client, node, nil)
+			} else {
+				err = Uncordon(client, node, nil)
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			node, err = client.Get(node.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if node.Spec.Unschedulable != test.cordon {
+				t.Errorf("node %q unschedulable %t (expected %t)", node.Name, node.Spec.Unschedulable, test.cordon)
+			}
+		})
+	}
+}
+
+func TestDrain(t *testing.T) {
+	labels := make(map[string]string)
+	labels["my_key"] = "my_value"
+	/* FIXME: these are not resource.Objects.  How to get them into NewSimpleClientset?
+	policy := &metav1.APIGroupList{
+		Groups: []metav1.APIGroup{
+			{
+				Name: "policy",
+				PreferredVersion: metav1.GroupVersionForDiscovery{
+					GroupVersion: "policy/v1beta1",
+				},
+			},
+		},
+	}
+
+	resourceList := &metav1.APIResourceList{
+		GroupVersion: "v1",
+	}
+
+	evictionResource := &metav1.APIResource{
+		Name: EvictionSubresource,
+		Kind: EvictionKind,
+	}*/
+
+	rc := &corev1.ReplicationController{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "rc",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Time{Time: time.Now()},
+			Labels:            labels,
+		},
+		Spec: corev1.ReplicationControllerSpec{
+			Selector: labels,
+		},
+	}
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "node",
+			CreationTimestamp: metav1.Time{Time: time.Now()},
+		},
+		Status: corev1.NodeStatus{},
+	}
+
+	rcPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "bar",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Time{Time: time.Now()},
+			Labels:            labels,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         "v1",
+					Kind:               "ReplicationController",
+					Name:               "rc",
+					UID:                "123",
+					BlockOwnerDeletion: boolptr(true),
+					Controller:         boolptr(true),
+				},
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "node",
+		},
+	}
+
+	ds := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "ds",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Time{Time: time.Now()},
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: labels},
+		},
+	}
+
+	dsPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "bar",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Time{Time: time.Now()},
+			Labels:            labels,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         "appsv1/v1",
+					Kind:               "DaemonSet",
+					Name:               "ds",
+					BlockOwnerDeletion: boolptr(true),
+					Controller:         boolptr(true),
+				},
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "node",
+		},
+	}
+
+	dsPodWithEmptyDir := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "bar",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Time{Time: time.Now()},
+			Labels:            labels,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         "apps/v1",
+					Kind:               "DaemonSet",
+					Name:               "ds",
+					BlockOwnerDeletion: boolptr(true),
+					Controller:         boolptr(true),
+				},
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "node",
+			Volumes: []corev1.Volume{
+				{
+					Name:         "scratch",
+					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: ""}},
+				},
+			},
+		},
+	}
+
+	orphanedDSpod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "bar",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Time{Time: time.Now()},
+			Labels:            labels,
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "node",
+		},
+	}
+
+	job := &batch.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "job",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Time{Time: time.Now()},
+		},
+		Spec: batch.JobSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: labels},
+		},
+	}
+
+	jobPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "bar",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Time{Time: time.Now()},
+			Labels:            labels,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         "v1",
+					Kind:               "Job",
+					Name:               "job",
+					BlockOwnerDeletion: boolptr(true),
+					Controller:         boolptr(true),
+				},
+			},
+		},
+	}
+
+	rs := &extensions.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "rs",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Time{Time: time.Now()},
+			Labels:            labels,
+		},
+		Spec: extensions.ReplicaSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: labels},
+		},
+	}
+
+	rsPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "bar",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Time{Time: time.Now()},
+			Labels:            labels,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         "v1",
+					Kind:               "ReplicaSet",
+					Name:               "rs",
+					BlockOwnerDeletion: boolptr(true),
+					Controller:         boolptr(true),
+				},
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "node",
+		},
+	}
+
+	nakedPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "bar",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Time{Time: time.Now()},
+			Labels:            labels,
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "node",
+		},
+	}
+
+	podWithEmptyDir := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "bar",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Time{Time: time.Now()},
+			Labels:            labels,
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "node",
+			Volumes: []corev1.Volume{
+				{
+					Name:         "scratch",
+					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: ""}},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		description        string
+		nodes              []string
+		options            *DrainOptions
+		objects            []runtime.Object
+		logEntries         []string
+		expectedDrainError string
+	}{
+		{
+			description: "RC-managed pod (delete)",
+			nodes:       []string{"node"},
+			options:     &DrainOptions{},
+			objects: []runtime.Object{
+				rc,
+				node,
+				rcPod,
+			},
+			logEntries: []string{
+				"cordoned node \"node\"",
+				"pod \"bar\" removed (deleted)",
+				"drained node \"node\"",
+			},
+		},
+		/*		{
+				description:  "RC-managed pod (evict)",
+				nodes:        []string{"node"},
+				options:      &DrainOptions{},
+				objects:      []runtime.Object{
+					policy,
+					resourceList,
+					evictionResource,
+					rc,
+					node,
+					rcPod,
+				},
+				logEntries: []string{
+					"cordoned node \"node\"",
+					"pod \"bar\" removed (evicted)",
+					"drained node \"node\"",
+				},
+			},*/
+		{
+			description: "DS-managed pod",
+			nodes:       []string{"node"},
+			options:     &DrainOptions{},
+			objects: []runtime.Object{
+				rc,
+				node,
+				ds,
+				dsPod,
+			},
+			expectedDrainError: "^DaemonSet-managed pods \\(use IgnoreDaemonsets to ignore\\): bar$",
+		},
+		{
+			description: "orphaned DS-managed pod",
+			nodes:       []string{"node"},
+			options:     &DrainOptions{},
+			objects: []runtime.Object{
+				node,
+				orphanedDSpod,
+			},
+			expectedDrainError: "^pods not managed by ReplicationController, ReplicaSet, Job, DaemonSet or StatefulSet \\(use Force to override\\): bar$",
+		},
+		{
+			description: "orphaned DS-managed pod with Force",
+			nodes:       []string{"node"},
+			options: &DrainOptions{
+				Force: true,
+			},
+			objects: []runtime.Object{
+				node,
+				orphanedDSpod,
+			},
+			logEntries: []string{
+				"cordoned node \"node\"",
+				fmt.Sprintf("%s: bar", kUnmanagedWarning),
+				"pod \"bar\" removed (deleted)",
+				"drained node \"node\"",
+			},
+		},
+		{
+			description: "DS-managed pod with IgnoreDaemonsets",
+			nodes:       []string{"node"},
+			options: &DrainOptions{
+				IgnoreDaemonsets: true,
+			},
+			objects: []runtime.Object{
+				rc,
+				node,
+				ds,
+				dsPod,
+			},
+			logEntries: []string{
+				"cordoned node \"node\"",
+				fmt.Sprintf("%s: bar", kDaemonsetWarning),
+				"drained node \"node\"",
+			},
+		},
+		{
+			description: "DS-managed pod with emptyDir with IgnoreDaemonsets",
+			nodes:       []string{"node"},
+			options: &DrainOptions{
+				IgnoreDaemonsets: true,
+			},
+			objects: []runtime.Object{
+				rc,
+				node,
+				ds,
+				dsPodWithEmptyDir,
+			},
+			logEntries: []string{
+				"cordoned node \"node\"",
+				fmt.Sprintf("%s: bar", kDaemonsetWarning),
+				"drained node \"node\"",
+			},
+		},
+		{
+			description: "Job-managed pod",
+			nodes:       []string{"node"},
+			options:     &DrainOptions{},
+			objects: []runtime.Object{
+				rc,
+				node,
+				job,
+				jobPod,
+			},
+			logEntries: []string{
+				"cordoned node \"node\"",
+				"pod \"bar\" removed (deleted)",
+				"drained node \"node\"",
+			},
+		},
+		{
+			description: "RS-managed pod",
+			nodes:       []string{"node"},
+			options:     &DrainOptions{},
+			objects: []runtime.Object{
+				rc,
+				node,
+				rs,
+				rsPod,
+			},
+			logEntries: []string{
+				"cordoned node \"node\"",
+				"pod \"bar\" removed (deleted)",
+				"drained node \"node\"",
+			},
+		},
+		{
+			description: "naked pod",
+			nodes:       []string{"node"},
+			options:     &DrainOptions{},
+			objects: []runtime.Object{
+				node,
+				nakedPod,
+			},
+			expectedDrainError: "^pods not managed by ReplicationController, ReplicaSet, Job, DaemonSet or StatefulSet \\(use Force to override\\): bar$",
+		},
+		{
+			description: "naked pod with Force",
+			nodes:       []string{"node"},
+			options: &DrainOptions{
+				Force: true,
+			},
+			objects: []runtime.Object{
+				node,
+				nakedPod,
+			},
+			logEntries: []string{
+				"cordoned node \"node\"",
+				fmt.Sprintf("%s: bar", kUnmanagedWarning),
+				"pod \"bar\" removed (deleted)",
+				"drained node \"node\"",
+			},
+		},
+		{
+			description: "pod with EmptyDir",
+			nodes:       []string{"node"},
+			options: &DrainOptions{
+				Force: true,
+			},
+			objects: []runtime.Object{
+				node,
+				podWithEmptyDir,
+			},
+			expectedDrainError: "^pods with local storage \\(use DeleteLocalData to override\\): bar$",
+		},
+		{
+			description: "pod with EmptyDir and DeleteLocalData",
+			nodes:       []string{"node"},
+			options: &DrainOptions{
+				DeleteLocalData: true,
+				Force:           true,
+			},
+			objects: []runtime.Object{
+				node,
+				podWithEmptyDir,
+			},
+			logEntries: []string{
+				"cordoned node \"node\"",
+				fmt.Sprintf("%s: bar; %s: bar", kLocalStorageWarning, kUnmanagedWarning),
+				"pod \"bar\" removed (deleted)",
+				"drained node \"node\"",
+			},
+		},
+		{
+			description: "empty node",
+			nodes:       []string{"node"},
+			options:     &DrainOptions{},
+			objects: []runtime.Object{
+				rc,
+				node,
+			},
+			logEntries: []string{
+				"cordoned node \"node\"",
+				"drained node \"node\"",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			if len(test.logEntries) > 0 && len(test.expectedDrainError) > 0 {
+				t.Error("logEntries set despite being masked by expectedDrainError")
+			}
+
+			client := fake.NewSimpleClientset(test.objects...)
+			logger := capture.New()
+			test.options.Logger = logger
+
+			nodes, err := GetNodes(client.CoreV1().Nodes(), test.nodes, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = Drain(client, nodes, test.options)
+			if err != nil {
+				if len(test.expectedDrainError) == 0 {
+					t.Fatal(err)
+				} else if !regexp.MustCompile(test.expectedDrainError).MatchString(err.Error()) {
+					t.Fatalf("%q does not match %q", err.Error(), test.expectedDrainError)
+				}
+				return
+			} else if len(test.expectedDrainError) > 0 {
+				t.Fatalf("expected error %q", test.expectedDrainError)
+			}
+
+			for i, expectedEntry := range test.logEntries {
+				if i >= len(logger.Entries) {
+					t.Errorf("missing expected entry %d: %q", i, expectedEntry)
+					continue
+				}
+				actualEntry := logger.Entries[i]
+				if actualEntry != expectedEntry {
+					t.Errorf("unexpected entry %d: %q (expected %q)", i, actualEntry, expectedEntry)
+				}
+			}
+			if len(logger.Entries) > len(test.logEntries) {
+				t.Errorf("additional unexpected entries: %v", logger.Entries[len(test.logEntries):])
+			}
+		})
+	}
+}
+
+func TestDeletePods(t *testing.T) {
+	ifHasBeenCalled := map[string]bool{}
+	tests := []struct {
+		description       string
+		interval          time.Duration
+		timeout           time.Duration
+		expectPendingPods bool
+		expectError       bool
+		expectedError     *error
+		getPodFn          func(namespace, name string) (*corev1.Pod, error)
+	}{
+		{
+			description:       "Wait for deleting to complete",
+			interval:          100 * time.Millisecond,
+			timeout:           10 * time.Second,
+			expectPendingPods: false,
+			expectError:       false,
+			expectedError:     nil,
+			getPodFn: func(namespace, name string) (*corev1.Pod, error) {
+				oldPodMap, _ := createPods(false)
+				newPodMap, _ := createPods(true)
+				if oldPod, found := oldPodMap[name]; found {
+					if _, ok := ifHasBeenCalled[name]; !ok {
+						ifHasBeenCalled[name] = true
+						return &oldPod, nil
+					}
+					if oldPod.ObjectMeta.Generation < 4 {
+						newPod := newPodMap[name]
+						return &newPod, nil
+					}
+					return nil, apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, name)
+
+				}
+				return nil, apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, name)
+			},
+		},
+		{
+			description:       "Deleting could timeout",
+			interval:          200 * time.Millisecond,
+			timeout:           3 * time.Second,
+			expectPendingPods: true,
+			expectError:       true,
+			expectedError:     &wait.ErrWaitTimeout,
+			getPodFn: func(namespace, name string) (*corev1.Pod, error) {
+				oldPodMap, _ := createPods(false)
+				if oldPod, found := oldPodMap[name]; found {
+					return &oldPod, nil
+				}
+				return nil, fmt.Errorf("%q: not found", name)
+			},
+		},
+		{
+			description:       "Client error could be passed out",
+			interval:          200 * time.Millisecond,
+			timeout:           5 * time.Second,
+			expectPendingPods: true,
+			expectError:       true,
+			expectedError:     nil,
+			getPodFn: func(namespace, name string) (*corev1.Pod, error) {
+				return nil, errors.New("This is a random error for testing")
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			_, pods := createPods(false)
+			pendingPods, err := waitForDelete(pods, test.interval, test.timeout, false, nil, test.getPodFn)
+
+			if test.expectError {
+				if err == nil {
+					t.Fatalf("%s: unexpected non-error", test.description)
+				} else if test.expectedError != nil {
+					if *test.expectedError != err {
+						t.Fatalf("%s: the error does not match expected error", test.description)
+					}
+				}
+			}
+			if !test.expectError && err != nil {
+				t.Fatalf("%s: unexpected error", test.description)
+			}
+			if test.expectPendingPods && len(pendingPods) == 0 {
+				t.Fatalf("%s: unexpected empty pods", test.description)
+			}
+			if !test.expectPendingPods && len(pendingPods) > 0 {
+				t.Fatalf("%s: unexpected pending pods", test.description)
+			}
+		})
+	}
+}
+
+func createPods(ifCreateNewPods bool) (map[string]corev1.Pod, []corev1.Pod) {
+	podMap := make(map[string]corev1.Pod)
+	podSlice := []corev1.Pod{}
+	for i := 0; i < 8; i++ {
+		var uid types.UID
+		if ifCreateNewPods {
+			uid = types.UID(i)
+		} else {
+			uid = types.UID(strconv.Itoa(i) + strconv.Itoa(i))
+		}
+		pod := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "pod" + strconv.Itoa(i),
+				Namespace:  "default",
+				UID:        uid,
+				Generation: int64(i),
+			},
+		}
+		podMap[pod.Name] = pod
+		podSlice = append(podSlice, pod)
+	}
+	return podMap, podSlice
+}
+
+type MyReq struct {
+	Request *http.Request
+}
+
+func defaultHeader() http.Header {
+	header := http.Header{}
+	header.Set("Content-Type", runtime.ContentTypeJSON)
+	return header
+}
+
+func objBody(codec runtime.Codec, obj runtime.Object) io.ReadCloser {
+	return ioutil.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(codec, obj))))
+}
+
+func stringBody(body string) io.ReadCloser {
+	return ioutil.NopCloser(bytes.NewReader([]byte(body)))
+}

--- a/vendor/github.com/openshift/cluster-api/pkg/controller/machine/actuator.go
+++ b/vendor/github.com/openshift/cluster-api/pkg/controller/machine/actuator.go
@@ -35,6 +35,8 @@ type Actuator interface {
 	Update(context.Context, *clusterv1.Cluster, *machinev1.Machine) error
 	// Checks if the machine currently exists.
 	Exists(context.Context, *clusterv1.Cluster, *machinev1.Machine) (bool, error)
+	// GetInstanceTypeDetails returns a struct of instance size details.
+	GetInstanceTypeDetails(context.Context, *machinev1.MachineSet) (map[string]string, error)
 }
 
 /// [Actuator]

--- a/vendor/github.com/openshift/cluster-api/pkg/controller/machine/testactuator.go
+++ b/vendor/github.com/openshift/cluster-api/pkg/controller/machine/testactuator.go
@@ -91,6 +91,12 @@ func (a *TestActuator) Exists(context.Context, *v1alpha1.Cluster, *v1beta1.Machi
 	return a.ExistsValue, nil
 }
 
+func (a *TestActuator) GetInstanceTypeDetails(_ context.Context, _ *v1beta1.MachineSet) (map[string]string, error) {
+	return map[string]string{
+	    "testactuator": "testing",
+	}, nil
+}
+
 func newTestActuator() *TestActuator {
 	ta := new(TestActuator)
 	ta.unblock = make(chan string)


### PR DESCRIPTION
Half-working pricing annotation controller.

We should use code-generation to incorporate the pricing similar to what the autoscaler does upstream, rather than attempt to use the pricing api (which is very problematic due to permissions, and region restrictions/networking).

Upstream cluster autoscaler downloads the pricing info for each provider, generates code with the pricing information, and that pricing information is built into the autoscaler binary.  We could utilize the same here (ideally, make that logic more portable in the upstream autoscaler as well so we can just import the functionality).