### PR TITLE
Bug 1796599: Save status before Patch()

### DIFF
--- a/pkg/actuators/machine/actuator.go
+++ b/pkg/actuators/machine/actuator.go
@@ -629,11 +629,15 @@ func getClusterID(machine *machinev1.Machine) (string, bool) {
 }
 
 func (a *Actuator) patchMachine(ctx context.Context, machine *machinev1.Machine, machineToBePatched client.Patch) error {
+	statusCopy := *machine.Status.DeepCopy()
+
 	// Patch machine
 	if err := a.client.Patch(ctx, machine, machineToBePatched); err != nil {
 		klog.Errorf("Failed to update machine %q: %v", machine.GetName(), err)
 		return err
 	}
+
+	machine.Status = statusCopy
 
 	//Patch status
 	if err := a.client.Status().Patch(ctx, machine, machineToBePatched); err != nil {


### PR DESCRIPTION
Currently, the actual status never gets updated. First `Patch()` call updates machine, but doesn't update the status, which means that status remains outdated. The result of the first `Patch()` call is an updated machine with an outdated status. This result is saved to `machine` that we pass as an argument. When we call `Status().Patch()` later with the same machine, actual status never gets there.
The solution is to save status, before calling first `Patch()`
