### PR TITLE
support KMS key for EBS encryption

### DIFF
--- a/pkg/actuators/machine/instances.go
+++ b/pkg/actuators/machine/instances.go
@@ -214,8 +214,10 @@ func getBlockDeviceMappings(blockDeviceMappings []providerconfigv1.BlockDeviceMa
 	}
 
 	if aws.StringValue(blockDeviceMappings[0].EBS.KMSKey.ID) != "" {
+		klog.V(3).Infof("Using KMS key ID %q for encrypting EBS volume", *blockDeviceMappings[0].EBS.KMSKey.ID)
 		blockDeviceMapping.Ebs.KmsKeyId = blockDeviceMappings[0].EBS.KMSKey.ID
 	} else if aws.StringValue(blockDeviceMappings[0].EBS.KMSKey.ARN) != "" {
+		klog.V(3).Info("Using KMS key ARN for encrypting EBS volume") // ARN usually have account ids, therefore are sensitive data so shouldn't log the value
 		blockDeviceMapping.Ebs.KmsKeyId = blockDeviceMappings[0].EBS.KMSKey.ARN
 	}
 

--- a/pkg/actuators/machine/instances.go
+++ b/pkg/actuators/machine/instances.go
@@ -212,6 +212,13 @@ func getBlockDeviceMappings(blockDeviceMappings []providerconfigv1.BlockDeviceMa
 			Encrypted:  blockDeviceMappings[0].EBS.Encrypted,
 		},
 	}
+
+	if aws.StringValue(blockDeviceMappings[0].EBS.KMSKey.ID) != "" {
+		blockDeviceMapping.Ebs.KmsKeyId = blockDeviceMappings[0].EBS.KMSKey.ID
+	} else if aws.StringValue(blockDeviceMappings[0].EBS.KMSKey.ARN) != "" {
+		blockDeviceMapping.Ebs.KmsKeyId = blockDeviceMappings[0].EBS.KMSKey.ARN
+	}
+
 	if *volumeType == "io1" {
 		blockDeviceMapping.Ebs.Iops = blockDeviceMappings[0].EBS.Iops
 	}

--- a/pkg/apis/awsproviderconfig/v1beta1/awsmachineproviderconfig_types.go
+++ b/pkg/apis/awsproviderconfig/v1beta1/awsmachineproviderconfig_types.go
@@ -180,6 +180,9 @@ type EBSBlockDeviceSpec struct {
 	// may only be attached to machines that support Amazon EBS encryption.
 	Encrypted *bool `json:"encrypted,omitempty"`
 
+	// Indicates the KMS key that should be used to encrypt the Amazon EBS volume.
+	KMSKey AWSResourceReference `json:"kmsKey,omitempty"`
+
 	// The number of I/O operations per second (IOPS) that the volume supports.
 	// For io1, this represents the number of IOPS that are provisioned for the
 	// volume. For gp2, this represents the baseline performance of the volume and

--- a/pkg/apis/awsproviderconfig/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/awsproviderconfig/v1beta1/zz_generated.deepcopy.go
@@ -272,6 +272,7 @@ func (in *EBSBlockDeviceSpec) DeepCopyInto(out *EBSBlockDeviceSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	in.KMSKey.DeepCopyInto(&out.KMSKey)
 	if in.Iops != nil {
 		in, out := &in.Iops, &out.Iops
 		*out = new(int64)


### PR DESCRIPTION
For encyrpted EBS volumes allow users to provide ARN to the KMS keys to use. It uses the ID > ARN preference order similar to other functions

- Why only ID and ARN?

the KMS keys don't really support filtering the KMS keys based on tags. [1] & [2]

[1]: https://docs.aws.amazon.com/cli/latest/reference/kms/index.html#cli-aws-kms
[2]: https://docs.aws.amazon.com/cli/latest/reference/kms/describe-key.html