### PR TITLE
[OCPCLOUD-801] Add support for Spot Instances in MachineProviderConfig

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/onsi/gomega v1.7.0
 
 	// kube 1.16
-	github.com/openshift/machine-api-operator v0.2.1-0.20200310180732-c63fa2b143f0
+	github.com/openshift/machine-api-operator v0.2.1-0.20200320004730-01120a0337a6
 	github.com/pkg/errors v0.8.1
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -295,8 +295,8 @@ github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQ
 github.com/openshift/api v0.0.0-20200127192224-ffde1bfabb9f/go.mod h1:fT6U/JfG8uZzemTRwZA2kBDJP5nWz7v05UHnty/D+pk=
 github.com/openshift/client-go v0.0.0-20190617165122-8892c0adc000/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/openshift/cluster-version-operator v3.11.1-0.20190629164025-08cac1c02538+incompatible/go.mod h1:0BbpR1mrN0F2ZRae5N1XHcytmkvVPaeKgSQwRRBWugc=
-github.com/openshift/machine-api-operator v0.2.1-0.20200310180732-c63fa2b143f0 h1:Na0422T5qq9e4AtBqH4hyqujESg29Akrf2asy/kc02U=
-github.com/openshift/machine-api-operator v0.2.1-0.20200310180732-c63fa2b143f0/go.mod h1:b3huCV+DbroXP1sHtsU5xBwx97zqc6GKB5owyl2zsNM=
+github.com/openshift/machine-api-operator v0.2.1-0.20200320004730-01120a0337a6 h1:trxpQtPocJw36OV8HU0M+Jl5Qi0cpLdU+nqEUeakGME=
+github.com/openshift/machine-api-operator v0.2.1-0.20200320004730-01120a0337a6/go.mod h1:b3huCV+DbroXP1sHtsU5xBwx97zqc6GKB5owyl2zsNM=
 github.com/operator-framework/operator-sdk v0.5.1-0.20190301204940-c2efe6f74e7b/go.mod h1:iVyukRkam5JZa8AnjYf+/G3rk7JI1+M6GsU0sq0B9NA=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/pkg/actuators/machine/actuator.go
+++ b/pkg/actuators/machine/actuator.go
@@ -148,6 +148,10 @@ func (a *Actuator) setMachineCloudProviderSpecifics(machine *machinev1.Machine, 
 		machine.Labels = make(map[string]string)
 	}
 
+	if machine.Spec.Labels == nil {
+		machine.Spec.Labels = make(map[string]string)
+	}
+
 	if machine.Annotations == nil {
 		machine.Annotations = make(map[string]string)
 	}
@@ -171,6 +175,11 @@ func (a *Actuator) setMachineCloudProviderSpecifics(machine *machinev1.Machine, 
 
 	if instance.State != nil && instance.State.Name != nil {
 		machine.Annotations[machinecontroller.MachineInstanceStateAnnotationName] = aws.StringValue(instance.State.Name)
+	}
+
+	if instance.InstanceLifecycle != nil && *instance.InstanceLifecycle == ec2.InstanceLifecycleTypeSpot {
+		// Label on the Spec so that it is propogated to the Node
+		machine.Spec.Labels[machinecontroller.MachineInterruptibleInstanceLabelName] = ""
 	}
 
 	return nil

--- a/pkg/apis/awsprovider/v1beta1/awsproviderconfig_types.go
+++ b/pkg/apis/awsprovider/v1beta1/awsproviderconfig_types.go
@@ -91,6 +91,9 @@ type AWSMachineProviderConfig struct {
 	// BlockDevices is the set of block device mapping associated to this instance
 	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html
 	BlockDevices []BlockDeviceMappingSpec `json:"blockDevices,omitempty"`
+
+	// SpotMarketOptions allows users to configure instances to be run using AWS Spot instances.
+	SpotMarketOptions *SpotMarketOptions `json:"spotMarketOptions,omitempty"`
 }
 
 // BlockDeviceMappingSpec describes a block device mapping
@@ -165,6 +168,15 @@ type EBSBlockDeviceSpec struct {
 	// The volume type: gp2, io1, st1, sc1, or standard.
 	// Default: standard
 	VolumeType *string `json:"volumeType,omitempty"`
+}
+
+// SpotMarketOptions defines the options available to a user when configuring
+// Machines to run on Spot instances.
+// Most users should provide an empty struct.
+type SpotMarketOptions struct {
+	// The maximum price the user is willing to pay for their instances
+	// Default: On-Demand price
+	MaxPrice *string `json:"maxPrice,omitempty"`
 }
 
 // AWSResourceReference is a reference to a specific AWS resource by ID, ARN, or filters.

--- a/vendor/github.com/openshift/machine-api-operator/pkg/controller/machine/controller.go
+++ b/vendor/github.com/openshift/machine-api-operator/pkg/controller/machine/controller.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"time"
 
-	commonerrors "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	"github.com/openshift/machine-api-operator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
@@ -59,6 +58,9 @@ const (
 
 	// MachineInstanceTypeLabelName as annotation name for a machine instance type
 	MachineInstanceTypeLabelName = "machine.openshift.io/instance-type"
+
+	// MachineInterruptibleInstanceLabelName as annotaiton name for interruptible instances
+	MachineInterruptibleInstanceLabelName = "machine.openshift.io/interruptible-instance"
 
 	// https://github.com/openshift/enhancements/blob/master/enhancements/machine-instance-lifecycle.md
 	// This is not a transient error, but
@@ -406,7 +408,7 @@ func delayIfRequeueAfterError(err error) (reconcile.Result, error) {
 func isInvalidMachineConfigurationError(err error) bool {
 	switch t := err.(type) {
 	case *MachineError:
-		if t.Reason == commonerrors.InvalidConfigurationMachineError {
+		if t.Reason == machinev1.InvalidConfigurationMachineError {
 			klog.Infof("Actuator returned invalid configuration error: %v", err)
 			return true
 		}
@@ -442,10 +444,7 @@ func machineHasNode(machine *machinev1.Machine) bool {
 }
 
 func machineIsFailed(machine *machinev1.Machine) bool {
-	if stringPointerDeref(machine.Status.Phase) == phaseFailed {
-		return true
-	}
-	return false
+	return stringPointerDeref(machine.Status.Phase) == phaseFailed
 }
 
 func nodeIsUnreachable(node *corev1.Node) bool {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -143,7 +143,7 @@ github.com/onsi/gomega/matchers/support/goraph/edge
 github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
-# github.com/openshift/machine-api-operator v0.2.1-0.20200310180732-c63fa2b143f0
+# github.com/openshift/machine-api-operator v0.2.1-0.20200320004730-01120a0337a6
 github.com/openshift/machine-api-operator/cmd/machineset
 github.com/openshift/machine-api-operator/pkg/apis/machine
 github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1


### PR DESCRIPTION
This adds `SpotMarketOptions` to the `AWSMachineProviderConfig` and then uses the values from this configuration to set the required options in the `ec2. RunInstancesInput` to launch the instances as Spot instances. This is implemented as described in https://github.com/openshift/enhancements/pull/199

Additionally it adds a label with the Instance Lifecycle to the `Machine.Spec` so that this can be propagated onto Nodes for node affinity and selection purposes. This is implemented as describe in https://github.com/openshift/enhancements/pull/251