### PR TITLE
[OCPCLOUD-802] Add Spot terminationion notice handler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS builder
 WORKDIR /go/src/sigs.k8s.io/cluster-api-provider-aws
 COPY . .
 # VERSION env gets set in the openshift/release image and refers to the golang version, which interfers with our own

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,3 +14,4 @@ RUN INSTALL_PKGS=" \
     yum clean all
 COPY --from=builder /go/src/sigs.k8s.io/cluster-api-provider-aws/bin/manager /
 COPY --from=builder /go/src/sigs.k8s.io/cluster-api-provider-aws/bin/machine-controller-manager /
+COPY --from=builder /go/src/sigs.k8s.io/cluster-api-provider-aws/bin/termination-handler /

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.13 AS builder
 WORKDIR /go/src/sigs.k8s.io/cluster-api-provider-aws
 COPY . .
 # VERSION env gets set in the openshift/release image and refers to the golang version, which interfers with our own

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ ifeq ($(NO_DOCKER), 1)
   IMAGE_BUILD_CMD = imagebuilder
   CGO_ENABLED = 1
 else
-  DOCKER_CMD := docker run --rm -e CGO_ENABLED=1 -v "$(PWD)":/go/src/sigs.k8s.io/cluster-api-provider-aws:Z -w /go/src/sigs.k8s.io/cluster-api-provider-aws openshift/origin-release:golang-1.12
+  DOCKER_CMD := docker run --rm -e CGO_ENABLED=1 -v "$(PWD)":/go/src/sigs.k8s.io/cluster-api-provider-aws:Z -w /go/src/sigs.k8s.io/cluster-api-provider-aws openshift/origin-release:golang-1.13
   IMAGE_BUILD_CMD = docker build
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,8 @@ build: ## build binaries
                -ldflags "$(LD_FLAGS)" "$(REPO_PATH)/cmd/manager"
 	$(DOCKER_CMD) go build $(GOGCFLAGS) -o bin/manager -ldflags '-extldflags "-static"' \
                "$(REPO_PATH)/vendor/github.com/openshift/machine-api-operator/cmd/machineset"
+	$(DOCKER_CMD) go build $(GOGCFLAGS) -o "bin/termination-handler" \
+	             -ldflags "$(LD_FLAGS)" "$(REPO_PATH)/cmd/termination-handler"						 
 
 aws-actuator:
 	$(DOCKER_CMD) go build $(GOGCFLAGS) -o bin/aws-actuator sigs.k8s.io/cluster-api-provider-aws/cmd/aws-actuator

--- a/cmd/termination-handler/main.go
+++ b/cmd/termination-handler/main.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"k8s.io/klog"
+	"k8s.io/klog/klogr"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/termination"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/version"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+func main() {
+	var printVersion bool
+	flag.BoolVar(&printVersion, "version", false, "print version and exit")
+
+	klog.InitFlags(nil)
+	logger := klogr.New()
+
+	pollIntervalSeconds := flag.Int64("poll-interval-seconds", 5, "interval in seconds at which termination notice endpoint should be checked (Default: 5)")
+	nodeName := flag.String("node-name", "", "name of the node that the termination handler is running on")
+	flag.Set("logtostderr", "true")
+	flag.Parse()
+
+	if printVersion {
+		fmt.Println(version.String)
+		os.Exit(0)
+	}
+
+	// Get a config to talk to the apiserver
+	cfg, err := config.GetConfig()
+	if err != nil {
+		logger.Error(err, "Error getting configuration")
+		return
+	}
+
+	// Get the poll interval as a duration from the `poll-interval-seconds` flag
+	pollInterval := time.Duration(*pollIntervalSeconds) * time.Second
+
+	// Construct a termination handler
+	handler, err := termination.NewHandler(logger, cfg, pollInterval, *nodeName)
+	if err != nil {
+		logger.Error(err, "Error constructing termination handler")
+		return
+	}
+
+	// Start the termination handler
+	if err := handler.Run(ctrl.SetupSignalHandler()); err != nil {
+		logger.Error(err, "Error starting termination handler")
+		return
+	}
+}

--- a/cmd/termination-handler/main.go
+++ b/cmd/termination-handler/main.go
@@ -39,6 +39,7 @@ func main() {
 
 	pollIntervalSeconds := flag.Int64("poll-interval-seconds", 5, "interval in seconds at which termination notice endpoint should be checked (Default: 5)")
 	nodeName := flag.String("node-name", "", "name of the node that the termination handler is running on")
+	namespace := flag.String("namespace", "", "namespace that the machine for the node should live in. If unspecified, the look for machines across all namespaces.")
 	flag.Set("logtostderr", "true")
 	flag.Parse()
 
@@ -58,7 +59,7 @@ func main() {
 	pollInterval := time.Duration(*pollIntervalSeconds) * time.Second
 
 	// Construct a termination handler
-	handler, err := termination.NewHandler(logger, cfg, pollInterval, *nodeName)
+	handler, err := termination.NewHandler(logger, cfg, pollInterval, *namespace, *nodeName)
 	if err != nil {
 		logger.Error(err, "Error constructing termination handler")
 		return

--- a/pkg/termination/handler.go
+++ b/pkg/termination/handler.go
@@ -1,0 +1,84 @@
+package termination
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	awsTerminationEndpointURL = "http://169.254.169.254/latest/meta-data/spot/termination-time"
+)
+
+// Handler represents a handler that will run to check the termination
+// notice endpoint and delete Machine's if the instance termination notice is fulfilled.
+type Handler interface {
+	Run(stop <-chan struct{}) error
+}
+
+// NewHandler constructs a new Handler
+func NewHandler(logger logr.Logger, cfg *rest.Config, pollInterval time.Duration, nodeName string) (Handler, error) {
+	c, err := client.New(cfg, client.Options{})
+	if err != nil {
+		return nil, fmt.Errorf("error creating client: %v", err)
+	}
+
+	pollURL, err := url.Parse(awsTerminationEndpointURL)
+	if err != nil {
+		// This should never happen
+		panic(err)
+	}
+
+	return &handler{
+		client:       c,
+		pollURL:      pollURL,
+		pollInterval: pollInterval,
+		nodeName:     nodeName,
+		log:          logger,
+	}, nil
+}
+
+// handler implements the logic to check the termination endpoint and delete the
+// machine associated with the node
+type handler struct {
+	client       client.Client
+	pollURL      *url.URL
+	pollInterval time.Duration
+	nodeName     string
+	log          logr.Logger
+}
+
+// Run starts the handler and runs the termination logic
+func (h *handler) Run(stop <-chan struct{}) error {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errs := make(chan error, 1)
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		errs <- h.run(ctx, wg)
+	}()
+
+	select {
+	case <-stop:
+		cancel()
+		// Wait for run to stop
+		wg.Wait()
+		return nil
+	case err := <-errs:
+		cancel()
+		return err
+	}
+}
+
+func (h *handler) run(ctx context.Context, wg *sync.WaitGroup) error {
+	defer wg.Done()
+
+	return fmt.Errorf("not implemented")
+}

--- a/pkg/termination/handler.go
+++ b/pkg/termination/handler.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -34,6 +35,8 @@ func NewHandler(logger logr.Logger, cfg *rest.Config, pollInterval time.Duration
 		// This should never happen
 		panic(err)
 	}
+
+	logger = logger.WithValues("node", nodeName)
 
 	return &handler{
 		client:       c,
@@ -80,5 +83,18 @@ func (h *handler) Run(stop <-chan struct{}) error {
 func (h *handler) run(ctx context.Context, wg *sync.WaitGroup) error {
 	defer wg.Done()
 
+	machine, err := h.getMachineForNode(ctx)
+	if err != nil {
+		return fmt.Errorf("error fetching machine for node (%q): %v", h.nodeName, err)
+	}
+
+	logger := h.log.WithValues("namespace", machine.Namespace, "machine", machine.Name)
+	logger.V(1).Info("Monitoring node for machine")
+
 	return fmt.Errorf("not implemented")
+}
+
+// getMachineForNodeName finds the Machine associated with the Node name given
+func (h *handler) getMachineForNode(ctx context.Context) (*machinev1.Machine, error) {
+	return nil, fmt.Errorf("machine not found for node %q", h.nodeName)
 }

--- a/pkg/termination/handler_test.go
+++ b/pkg/termination/handler_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package termination
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/klog/klogr"
+)
+
+var _ = Describe("Handler Suite", func() {
+	var terminationServer *httptest.Server
+	var httpHandler http.Handler
+	var nodeName string
+	var stop chan struct{}
+	var errs chan error
+	var h *handler
+
+	BeforeEach(func() {
+		// Reset test vars
+		terminationServer = nil
+		httpHandler = nil
+		nodeName = "testNode"
+
+		h = &handler{
+			client:       k8sClient,
+			pollInterval: 100 * time.Millisecond,
+			nodeName:     nodeName,
+			log:          klogr.New(),
+		}
+	})
+
+	JustBeforeEach(func() {
+		Expect(httpHandler).ToNot(BeNil())
+		terminationServer = httptest.NewServer(httpHandler)
+
+		pollURL, err := url.Parse(terminationServer.URL)
+		Expect(err).ToNot(HaveOccurred())
+		h.pollURL = pollURL
+
+		stop, errs = StartTestHandler(h)
+	})
+
+	AfterEach(func() {
+		if !isClosed(stop) {
+			close(stop)
+		}
+		terminationServer.Close()
+	})
+
+	Context("when the handler is stopped", func() {
+		BeforeEach(func() {
+			httpHandler = newMockHTTPHandler(func(rw http.ResponseWriter, req *http.Request) {
+				rw.WriteHeader(404)
+			})
+		})
+
+		JustBeforeEach(func() {
+			close(stop)
+		})
+
+		It("should not return an error", func() {
+			Eventually(errs).Should(Receive(BeNil()))
+		})
+	})
+})
+
+// mockHTTPHandler is used to mock the pollURL responses during tests
+type mockHTTPHandler struct {
+	handleFunc func(rw http.ResponseWriter, req *http.Request)
+}
+
+// ServeHTTP implements the http.Handler interface
+func (m *mockHTTPHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	m.handleFunc(rw, req)
+}
+
+// newMockHTTPHandler constructs a mockHTTPHandler with the given handleFunc
+func newMockHTTPHandler(handleFunc func(http.ResponseWriter, *http.Request)) http.Handler {
+	return &mockHTTPHandler{handleFunc: handleFunc}
+}
+
+// isClosed checks if a channel is closed already
+func isClosed(ch <-chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+	}
+
+	return false
+}

--- a/pkg/termination/handler_test.go
+++ b/pkg/termination/handler_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package termination
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -21,8 +22,17 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/klogr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+var notFoundFunc = func(rw http.ResponseWriter, req *http.Request) {
+	rw.WriteHeader(404)
+}
 
 var _ = Describe("Handler Suite", func() {
 	var terminationServer *httptest.Server
@@ -36,7 +46,8 @@ var _ = Describe("Handler Suite", func() {
 		// Reset test vars
 		terminationServer = nil
 		httpHandler = nil
-		nodeName = "testNode"
+		nodeName = "test-node"
+		httpHandler = newMockHTTPHandler(notFoundFunc)
 
 		h = &handler{
 			client:       k8sClient,
@@ -62,21 +73,76 @@ var _ = Describe("Handler Suite", func() {
 			close(stop)
 		}
 		terminationServer.Close()
+
+		Expect(deleteAllMachines(k8sClient)).To(Succeed())
 	})
 
 	Context("when the handler is stopped", func() {
-		BeforeEach(func() {
-			httpHandler = newMockHTTPHandler(func(rw http.ResponseWriter, req *http.Request) {
-				rw.WriteHeader(404)
-			})
-		})
-
 		JustBeforeEach(func() {
 			close(stop)
 		})
 
 		It("should not return an error", func() {
 			Eventually(errs).Should(Receive(BeNil()))
+		})
+	})
+
+	Context("when no machine exists for the node", func() {
+		It("should return an error upon starting", func() {
+			Eventually(errs).Should(Receive(MatchError("error fetching machine for node (\"test-node\"): machine not found for node \"test-node\"")))
+		})
+	})
+
+	Context("getMachineForNode", func() {
+		var machine *machinev1.Machine
+		var err error
+
+		JustBeforeEach(func() {
+			machine, err = h.getMachineForNode(ctx)
+		})
+
+		Context("with a broken client", func() {
+			BeforeEach(func() {
+				brokenClient, err := client.New(cfg, client.Options{Scheme: runtime.NewScheme()})
+				Expect(err).ToNot(HaveOccurred())
+				h.client = brokenClient
+			})
+
+			It("should return an error", func() {
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(HavePrefix("error listing machines: no kind is registered for the type v1beta1.MachineList in scheme"))
+			})
+
+			It("should not return a machine", func() {
+				Expect(machine).To(BeNil())
+			})
+		})
+
+		Context("with no machine for the node name", func() {
+			It("should return an error", func() {
+				Expect(err).To(MatchError("machine not found for node \"test-node\""))
+			})
+
+			It("should not return a machine", func() {
+				Expect(machine).To(BeNil())
+			})
+		})
+
+		Context("with a machine matching the node name", func() {
+			var testMachine *machinev1.Machine
+
+			BeforeEach(func() {
+				testMachine = newTestMachine("test-machine", "test-namespace", nodeName)
+				createMachine(testMachine)
+			})
+
+			It("should not return an error", func() {
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should return a machine", func() {
+				Expect(machine).To(Equal(testMachine))
+			})
 		})
 	})
 })
@@ -105,4 +171,54 @@ func isClosed(ch <-chan struct{}) bool {
 	}
 
 	return false
+}
+
+func deleteAllMachines(c client.Client) error {
+	machineList := &machinev1.MachineList{}
+	err := c.List(ctx, machineList)
+	if err != nil {
+		return fmt.Errorf("error listing machines: %v", err)
+	}
+
+	// Delete all machines found
+	for _, machine := range machineList.Items {
+		m := machine
+		err := c.Delete(ctx, &m)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func newTestMachine(name, namespace, nodeName string) *machinev1.Machine {
+	return &machinev1.Machine{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Machine",
+			APIVersion: machinev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Status: machinev1.MachineStatus{
+			NodeRef: &corev1.ObjectReference{
+				Name: nodeName,
+			},
+		},
+	}
+}
+
+func createMachine(m *machinev1.Machine) {
+	typeMeta := m.TypeMeta
+	status := m.Status
+	Expect(k8sClient.Create(ctx, m)).To(Succeed())
+	m.Status = status
+	Expect(k8sClient.Status().Update(ctx, m)).To(Succeed())
+
+	// Fetch object to sync back to latest changes
+	key := client.ObjectKey{Namespace: m.Namespace, Name: m.Name}
+	Expect(k8sClient.Get(ctx, key, m)).To(Succeed())
+	// Restore TypeMeta as not restored by Get
+	m.TypeMeta = typeMeta
 }

--- a/pkg/termination/termination_suite_test.go
+++ b/pkg/termination/termination_suite_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package termination
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+)
+
+const (
+	timeout = 10 * time.Second
+)
+
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+
+	ctx = context.Background()
+)
+
+func TestReconciler(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Termination Handler Suite",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func() {
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crds")},
+	}
+	machinev1.AddToScheme(scheme.Scheme)
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(cfg).ToNot(BeNil())
+
+	k8sClient, err = client.New(cfg, client.Options{})
+	Expect(err).ToNot(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	Expect(testEnv.Stop()).To(Succeed())
+})
+
+// StartTestHandler starts the test handler
+func StartTestHandler(th Handler) (chan struct{}, chan error) {
+	stop := make(chan struct{})
+	errs := make(chan error)
+	go func() {
+		errs <- th.Run(stop)
+	}()
+	return stop, errs
+}


### PR DESCRIPTION
This adds a spot termination handler to the AWS actuator image.

This binary will run on nodes and poll the AWS metadata service to check if a node has been marked for termination or not.

Based on the [spot-instances](https://github.com/openshift/enhancements/blob/master/enhancements/machine-api/spot-instances.md) proposal

This has a similar purpose to the project https://github.com/aws/aws-node-termination-handler, however differs in a number of ways:
- This version only concerns itself with spot-termination events, not scheduled maintenance
- This version does not include reporting to slack/email etc
- This version deletes Machines rather than draining them
  - This leverages Machine API to handle the draining since this is already well implemented there 