### PR TITLE
Drop openssh from the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,5 @@ RUN unset VERSION \
  && GOPROXY=off NO_DOCKER=1 make build
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
-RUN INSTALL_PKGS=" \
-      openssh \
-      " && \
-    yum install -y $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
-    yum clean all
 COPY --from=builder /go/src/sigs.k8s.io/cluster-api-provider-aws/bin/machine-controller-manager /
 COPY --from=builder /go/src/sigs.k8s.io/cluster-api-provider-aws/bin/termination-handler /

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -6,11 +6,5 @@ RUN unset VERSION \
  && GOPROXY=off NO_DOCKER=1 make build
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
-RUN INSTALL_PKGS=" \
-      openssh \
-      " && \
-    yum install -y $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
-    yum clean all
 COPY --from=builder /go/src/sigs.k8s.io/cluster-api-provider-aws/bin/machine-controller-manager /
 COPY --from=builder /go/src/sigs.k8s.io/cluster-api-provider-aws/bin/termination-handler /


### PR DESCRIPTION
First introduced here https://github.com/openshift/cluster-api-provider-aws/pull/12/files. I don't see a reason to keep it.