### PR TITLE
Bug 1828288: Deprecate machine.openshift.io/memoryMb annotation in favour of machine.openshift.io/memory

### DIFF
--- a/pkg/actuators/machineset/controller.go
+++ b/pkg/actuators/machineset/controller.go
@@ -23,7 +23,7 @@ const (
 	// This is needed by the autoscaler to foresee upcoming capacity when scaling from zero.
 	// https://github.com/openshift/enhancements/pull/186
 	cpuKey    = "machine.openshift.io/vCPU"
-	memoryKey = "machine.openshift.io/memoryMb"
+	memoryKey = "machine.openshift.io/memory"
 	gpuKey    = "machine.openshift.io/GPU"
 )
 
@@ -121,7 +121,8 @@ func reconcile(machineSet *machinev1.MachineSet) (ctrl.Result, error) {
 
 	// TODO: get annotations keys from machine API
 	machineSet.Annotations[cpuKey] = strconv.FormatInt(instanceType.VCPU, 10)
-	machineSet.Annotations[memoryKey] = strconv.FormatInt(instanceType.MemoryMb, 10)
+	// See https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory
+	machineSet.Annotations[memoryKey] = fmt.Sprintf("%dMi", instanceType.MemoryMb)
 	machineSet.Annotations[gpuKey] = strconv.FormatInt(instanceType.GPU, 10)
 
 	return ctrl.Result{}, nil

--- a/pkg/actuators/machineset/controller_test.go
+++ b/pkg/actuators/machineset/controller_test.go
@@ -114,7 +114,7 @@ var _ = Describe("MachineSetReconciler", func() {
 			existingAnnotations: make(map[string]string),
 			expectedAnnotations: map[string]string{
 				cpuKey:    "8",
-				memoryKey: "16384",
+				memoryKey: "16384Mi",
 				gpuKey:    "0",
 			},
 			expectedEvents: []string{},
@@ -124,7 +124,7 @@ var _ = Describe("MachineSetReconciler", func() {
 			existingAnnotations: make(map[string]string),
 			expectedAnnotations: map[string]string{
 				cpuKey:    "64",
-				memoryKey: "786432",
+				memoryKey: "786432Mi",
 				gpuKey:    "16",
 			},
 			expectedEvents: []string{},
@@ -139,7 +139,7 @@ var _ = Describe("MachineSetReconciler", func() {
 				"existing": "annotation",
 				"annother": "existingAnnotation",
 				cpuKey:     "8",
-				memoryKey:  "16384",
+				memoryKey:  "16384Mi",
 				gpuKey:     "0",
 			},
 			expectedEvents: []string{},
@@ -209,7 +209,7 @@ func TestReconcile(t *testing.T) {
 			existingAnnotations: make(map[string]string),
 			expectedAnnotations: map[string]string{
 				cpuKey:    "8",
-				memoryKey: "16384",
+				memoryKey: "16384Mi",
 				gpuKey:    "0",
 			},
 			expectErr: false,
@@ -220,7 +220,7 @@ func TestReconcile(t *testing.T) {
 			existingAnnotations: make(map[string]string),
 			expectedAnnotations: map[string]string{
 				cpuKey:    "64",
-				memoryKey: "786432",
+				memoryKey: "786432Mi",
 				gpuKey:    "16",
 			},
 			expectErr: false,
@@ -236,7 +236,7 @@ func TestReconcile(t *testing.T) {
 				"existing": "annotation",
 				"annother": "existingAnnotation",
 				cpuKey:     "8",
-				memoryKey:  "16384",
+				memoryKey:  "16384Mi",
 				gpuKey:     "0",
 			},
 			expectErr: false,


### PR DESCRIPTION
Cluster autoscaler and aws/gcp/azure controllers should drop the
"machine.openshift.io/memoryMb" deprecated annotation and use only
"machine.openshift.io/memory".

This way controllers are responsible to set the unit format according to
https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory
while the autoscaler should be able to read it appropiately.
This is more robust and practical than the current approach and
assumptions.
https://bugzilla.redhat.com/show_bug.cgi?id=1828288