### PR TITLE
BUG 1831717: Ensure PublicIP is left out of JSON encoding if empty

### DIFF
--- a/pkg/apis/awsprovider/v1beta1/awsproviderconfig_types.go
+++ b/pkg/apis/awsprovider/v1beta1/awsproviderconfig_types.go
@@ -65,7 +65,7 @@ type AWSMachineProviderConfig struct {
 
 	// PublicIP specifies whether the instance should get a public IP. If not present,
 	// it should use the default of its subnet.
-	PublicIP *bool `json:"publicIp"`
+	PublicIP *bool `json:"publicIp,omitempty"`
 
 	// SecurityGroups is an array of references to security groups that should be applied to the
 	// instance.


### PR DESCRIPTION
Otherwise the value is rendered as `null` which is not a valid value for 
a boolean and causes marshalling errors

```
Invalid value: "The edited file failed validation": unknown object type "nil" in MachineSet.spec.template.spec.providerSpec.value.publicIp
```

Came across this while trying to `kubectl edit` a MachineSet

This will need the installer to bump their dependency to fix this bug