### PR TITLE
[OCPCLOUD-936] Bug 1902157: Mark node with condition when due for termination

### DIFF
--- a/pkg/termination/handler.go
+++ b/pkg/termination/handler.go
@@ -9,7 +9,8 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -17,18 +18,19 @@ import (
 )
 
 const (
-	awsTerminationEndpointURL = "http://169.254.169.254/latest/meta-data/spot/termination-time"
+	awsTerminationEndpointURL                           = "http://169.254.169.254/latest/meta-data/spot/termination-time"
+	terminatingConditionType   corev1.NodeConditionType = "Terminating"
+	terminationRequestedReason                          = "TerminationRequested"
 )
 
-// Handler represents a handler that will run to check the termination
-// notice endpoint and delete Machine's if the instance termination notice is fulfilled.
+// Handler represents a handler that will run to check the termination notice
+// endpoint and mark node for deletion if the instance termination notice is fulfilled.
 type Handler interface {
 	Run(stop <-chan struct{}) error
 }
 
 // NewHandler constructs a new Handler
 func NewHandler(logger logr.Logger, cfg *rest.Config, pollInterval time.Duration, namespace, nodeName string) (Handler, error) {
-	machinev1.AddToScheme(scheme.Scheme)
 	c, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	if err != nil {
 		return nil, fmt.Errorf("error creating client: %v", err)
@@ -52,8 +54,8 @@ func NewHandler(logger logr.Logger, cfg *rest.Config, pollInterval time.Duration
 	}, nil
 }
 
-// handler implements the logic to check the termination endpoint and delete the
-// machine associated with the node
+// handler implements the logic to check the termination endpoint and
+// marks the node for termination
 type handler struct {
 	client       client.Client
 	pollURL      *url.URL
@@ -89,13 +91,8 @@ func (h *handler) Run(stop <-chan struct{}) error {
 func (h *handler) run(ctx context.Context, wg *sync.WaitGroup) error {
 	defer wg.Done()
 
-	machine, err := h.getMachineForNode(ctx)
-	if err != nil {
-		return fmt.Errorf("error fetching machine for node (%q): %v", h.nodeName, err)
-	}
-
-	logger := h.log.WithValues("machine", machine.Name)
-	logger.V(1).Info("Monitoring node for machine")
+	logger := h.log.WithValues("node", h.nodeName)
+	logger.V(1).Info("Monitoring node termination")
 
 	if err := wait.PollImmediateUntil(h.pollInterval, func() (bool, error) {
 		resp, err := http.Get(h.pollURL.String())
@@ -119,27 +116,76 @@ func (h *handler) run(ctx context.Context, wg *sync.WaitGroup) error {
 	}
 
 	// Will only get here if the termination endpoint returned 200
-	logger.V(1).Info("Instance marked for termination, deleting Machine")
-	if err := h.client.Delete(ctx, machine); err != nil {
-		return fmt.Errorf("error deleting machine: %v", err)
+	logger.V(1).Info("Instance marked for termination, marking Node for deletion")
+	if err := h.markNodeForDeletion(ctx); err != nil {
+		return fmt.Errorf("error marking node: %v", err)
 	}
 
 	return nil
 }
 
-// getMachineForNodeName finds the Machine associated with the Node name given
-func (h *handler) getMachineForNode(ctx context.Context) (*machinev1.Machine, error) {
-	machineList := &machinev1.MachineList{}
-	err := h.client.List(ctx, machineList, client.InNamespace(h.namespace))
-	if err != nil {
-		return nil, fmt.Errorf("error listing machines: %v", err)
+func (h *handler) markNodeForDeletion(ctx context.Context) error {
+	node := &corev1.Node{}
+	if err := h.client.Get(ctx, client.ObjectKey{Name: h.nodeName}, node); err != nil {
+		return fmt.Errorf("error fetching node: %v", err)
 	}
 
-	for _, machine := range machineList.Items {
-		if machine.Status.NodeRef != nil && machine.Status.NodeRef.Name == h.nodeName {
-			return &machine, nil
+	addNodeTerminationCondition(node)
+	if err := h.client.Status().Update(ctx, node); err != nil {
+		return fmt.Errorf("error updating node status")
+	}
+	return nil
+}
+
+// nodeHasTerminationCondition checks whether the node already
+// has a condition with the terminatingConditionType type
+func nodeHasTerminationCondition(node *corev1.Node) bool {
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == terminatingConditionType {
+			return true
 		}
 	}
+	return false
+}
 
-	return nil, fmt.Errorf("machine not found for node %q", h.nodeName)
+// addNodeTerminationCondition will add a condition with a
+// terminatingConditionType type to the node
+func addNodeTerminationCondition(node *corev1.Node) {
+	now := metav1.Now()
+	terminatingCondition := corev1.NodeCondition{
+		Type:               terminatingConditionType,
+		Status:             corev1.ConditionTrue,
+		LastHeartbeatTime:  now,
+		LastTransitionTime: now,
+		Reason:             terminationRequestedReason,
+		Message:            "The cloud provider has marked this instance for termination",
+	}
+
+	if !nodeHasTerminationCondition(node) {
+		// No need to merge, just add the new condition to the end
+		node.Status.Conditions = append(node.Status.Conditions, terminatingCondition)
+		return
+	}
+
+	// The node already has a terminating condition,
+	// so make sure it has the correct status
+	conditions := []corev1.NodeCondition{}
+	for _, condition := range node.Status.Conditions {
+		if condition.Type != terminatingConditionType {
+			conditions = append(conditions, condition)
+			continue
+		}
+
+		// Condition type is terminating
+		if condition.Status == corev1.ConditionTrue {
+			// Condition already marked true, do not update
+			conditions = append(conditions, condition)
+			continue
+		}
+
+		// The existing terminating condition had the wrong status
+		conditions = append(conditions, terminatingCondition)
+	}
+
+	node.Status.Conditions = conditions
 }

--- a/pkg/termination/handler_test.go
+++ b/pkg/termination/handler_test.go
@@ -23,11 +23,8 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2/klogr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -40,9 +37,31 @@ var _ = Describe("Handler Suite", func() {
 	var terminationServer *httptest.Server
 	var httpHandler http.Handler
 	var nodeName string
+	var testNode *corev1.Node
 	var stop chan struct{}
 	var errs chan error
 	var h *handler
+
+	nodeMarkedForDeletion := func(nodeName string) func() (bool, error) {
+		key := client.ObjectKey{Name: nodeName}
+		return func() (bool, error) {
+			n := &corev1.Node{}
+			err := k8sClient.Get(ctx, key, n)
+			if err != nil {
+				return false, err
+			}
+			for _, condition := range n.Status.Conditions {
+				if condition.Type == terminatingConditionType {
+					if condition.Status == corev1.ConditionTrue {
+						return true, nil
+					}
+					// Found the condition with the right type, but wrong status
+					return false, nil
+				}
+			}
+			return false, nil
+		}
+	}
 
 	BeforeEach(func() {
 		// Reset test vars
@@ -52,6 +71,9 @@ var _ = Describe("Handler Suite", func() {
 		httpHandler = newMockHTTPHandler(notFoundFunc)
 		stop = nil
 		errs = nil
+
+		testNode = newTestNode(nodeName)
+		createNode(testNode)
 
 		// use NewHandler() instead of manual construction in order to test NewHandler() logic
 		// like checking that machine api is added to scheme
@@ -81,13 +103,14 @@ var _ = Describe("Handler Suite", func() {
 		}
 		terminationServer.Close()
 
-		Expect(deleteAllMachines(k8sClient)).To(Succeed())
+		Expect(deleteAllNodes(k8sClient)).To(Succeed())
 	})
 
 	Context("when running the handler", func() {
 		JustBeforeEach(func() {
 			stop, errs = StartTestHandler(h)
 		})
+
 		Context("when the handler is stopped", func() {
 			JustBeforeEach(func() {
 				close(stop)
@@ -98,20 +121,10 @@ var _ = Describe("Handler Suite", func() {
 			})
 		})
 
-		Context("when no machine exists for the node", func() {
-			It("should return an error upon starting", func() {
-				Eventually(errs).Should(Receive(MatchError("error fetching machine for node (\"test-node\"): machine not found for node \"test-node\"")))
-			})
-		})
-
-		Context("when a machine exists for the node", func() {
+		Context("when polling the termination endpoint", func() {
 			var counter int32
-			var testMachine *machinev1.Machine
 
 			BeforeEach(func() {
-				testMachine = newTestMachine("test-machine", testNamespace, nodeName)
-				createMachine(testMachine)
-
 				// Ensure the polling logic is excercised in tests
 				httpHandler = newMockHTTPHandler(func(rw http.ResponseWriter, req *http.Request) {
 					if atomic.LoadInt32(&counter) == 4 {
@@ -139,28 +152,14 @@ var _ = Describe("Handler Suite", func() {
 					Eventually(errs).Should(Receive(BeNil()))
 				})
 
-				It("should not delete the machine", func() {
-					key := client.ObjectKey{Namespace: testMachine.Namespace, Name: testMachine.Name}
-					Consistently(func() error {
-						m := &machinev1.Machine{}
-						return k8sClient.Get(ctx, key, m)
-					}).Should(Succeed())
+				It("should not mark the node for deletion", func() {
+					Consistently(nodeMarkedForDeletion(testNode.Name)).Should(BeFalse())
 				})
 			})
 
 			Context("and the instance termination notice is fulfilled", func() {
-				It("should delete the machine", func() {
-					key := client.ObjectKey{Namespace: testMachine.Namespace, Name: testMachine.Name}
-					Eventually(func() error {
-						m := &machinev1.Machine{}
-						err := k8sClient.Get(ctx, key, m)
-						if err != nil && errors.IsNotFound(err) {
-							return nil
-						} else if err != nil {
-							return err
-						}
-						return fmt.Errorf("machine not yet deleted")
-					}).Should(Succeed())
+				It("should mark the node for deletion", func() {
+					Eventually(nodeMarkedForDeletion(testNode.Name)).Should(BeTrue())
 				})
 			})
 
@@ -169,12 +168,8 @@ var _ = Describe("Handler Suite", func() {
 					httpHandler = newMockHTTPHandler(notFoundFunc)
 				})
 
-				It("should not delete the machine", func() {
-					key := client.ObjectKey{Namespace: testMachine.Namespace, Name: testMachine.Name}
-					Consistently(func() error {
-						m := &machinev1.Machine{}
-						return k8sClient.Get(ctx, key, m)
-					}).Should(Succeed())
+				It("should not mark the node for deletion", func() {
+					Consistently(nodeMarkedForDeletion(testNode.Name)).Should(BeFalse())
 				})
 			})
 
@@ -195,11 +190,7 @@ var _ = Describe("Handler Suite", func() {
 				})
 
 				It("should not delete the machine", func() {
-					key := client.ObjectKey{Namespace: testMachine.Namespace, Name: testMachine.Name}
-					Consistently(func() error {
-						m := &machinev1.Machine{}
-						return k8sClient.Get(ctx, key, m)
-					}).Should(Succeed())
+					Consistently(nodeMarkedForDeletion(testNode.Name)).Should(BeFalse())
 				})
 			})
 
@@ -209,69 +200,110 @@ var _ = Describe("Handler Suite", func() {
 				})
 
 				It("should return an error", func() {
-					Eventually(errs).Should(Receive(MatchError("error polling termination endpoint: could not get URL \"abc#1://localhost\": Get abc#1://localhost: unsupported protocol scheme \"\"")))
+					Eventually(errs).Should(Receive(MatchError(ContainSubstring("error polling termination endpoint: could not get URL \"abc#1://localhost\":"))))
 				})
 
 				It("should not delete the machine", func() {
-					key := client.ObjectKey{Namespace: testMachine.Namespace, Name: testMachine.Name}
-					Consistently(func() error {
-						m := &machinev1.Machine{}
-						return k8sClient.Get(ctx, key, m)
-					}).Should(Succeed())
+					Consistently(nodeMarkedForDeletion(testNode.Name)).Should(BeFalse())
 				})
 			})
 		})
-	})
 
-	Context("getMachineForNode", func() {
-		var machine *machinev1.Machine
-		var err error
-
-		JustBeforeEach(func() {
-			machine, err = h.getMachineForNode(ctx)
-		})
-
-		Context("with a broken client", func() {
-			BeforeEach(func() {
-				brokenClient, err := client.New(cfg, client.Options{Scheme: runtime.NewScheme()})
-				Expect(err).ToNot(HaveOccurred())
-				h.client = brokenClient
+		Context("addNodeTerminationCondition", func() {
+			JustBeforeEach(func() {
+				addNodeTerminationCondition(testNode)
 			})
 
-			It("should return an error", func() {
-				Expect(err).ToNot(BeNil())
-				Expect(err.Error()).To(HavePrefix("error listing machines: no kind is registered for the type v1beta1.MachineList in scheme"))
+			Context("with no existing conditions", func() {
+				BeforeEach(func() {
+					Expect(testNode.Status.Conditions).To(HaveLen(0))
+				})
+
+				It("should add the condition to the node", func() {
+					Expect(testNode.Status.Conditions).To(HaveLen(1))
+					condition := testNode.Status.Conditions[0]
+					Expect(condition.Type).To(Equal(terminatingConditionType))
+					Expect(condition.Status).To(Equal(corev1.ConditionTrue))
+					Expect(condition.Reason).To(Equal(terminationRequestedReason))
+				})
 			})
 
-			It("should not return a machine", func() {
-				Expect(machine).To(BeNil())
+			Context("with the terminating condition with the correct status", func() {
+				var updated *metav1.Time
+
+				BeforeEach(func() {
+					now := metav1.Now()
+					updated = &now
+					testNode.Status.Conditions = []corev1.NodeCondition{
+						{
+							Type:               terminatingConditionType,
+							Status:             corev1.ConditionTrue,
+							Reason:             terminationRequestedReason,
+							LastTransitionTime: now,
+							LastHeartbeatTime:  now,
+						},
+					}
+				})
+
+				It("should not update the condition on the node", func() {
+					Expect(testNode.Status.Conditions).To(HaveLen(1))
+					condition := testNode.Status.Conditions[0]
+					Expect(condition.Type).To(Equal(terminatingConditionType))
+					Expect(condition.Status).To(Equal(corev1.ConditionTrue))
+					Expect(condition.Reason).To(Equal(terminationRequestedReason))
+					Expect(condition.LastTransitionTime).To(Equal(*updated))
+					Expect(condition.LastHeartbeatTime).To(Equal(*updated))
+				})
 			})
-		})
 
-		Context("with no machine for the node name", func() {
-			It("should return an error", func() {
-				Expect(err).To(MatchError("machine not found for node \"test-node\""))
+			Context("with the terminating condition with the incorrect status", func() {
+				var updated *metav1.Time
+
+				BeforeEach(func() {
+					now := metav1.Now()
+					updated = &now
+					testNode.Status.Conditions = []corev1.NodeCondition{
+						{
+							Type:               terminatingConditionType,
+							Status:             corev1.ConditionFalse,
+							Reason:             terminationRequestedReason,
+							LastTransitionTime: now,
+							LastHeartbeatTime:  now,
+						},
+					}
+				})
+
+				It("should update the condition on the node", func() {
+					Expect(testNode.Status.Conditions).To(HaveLen(1))
+					condition := testNode.Status.Conditions[0]
+					Expect(condition.Type).To(Equal(terminatingConditionType))
+					Expect(condition.Status).To(Equal(corev1.ConditionTrue))
+					Expect(condition.Reason).To(Equal(terminationRequestedReason))
+					Expect(condition.LastTransitionTime).ToNot(Equal(*updated))
+					Expect(condition.LastHeartbeatTime).ToNot(Equal(*updated))
+				})
 			})
 
-			It("should not return a machine", func() {
-				Expect(machine).To(BeNil())
-			})
-		})
+			Context("with existing conditions", func() {
+				var existingCondition *corev1.NodeCondition
 
-		Context("with a machine matching the node name", func() {
-			var testMachine *machinev1.Machine
+				BeforeEach(func() {
+					now := metav1.Now()
+					existingCondition = &corev1.NodeCondition{
+						Type:               corev1.NodeReady,
+						Status:             corev1.ConditionFalse,
+						Reason:             "Unknown",
+						LastTransitionTime: now,
+						LastHeartbeatTime:  now,
+					}
 
-			BeforeEach(func() {
-				testMachine = newTestMachine("test-machine", testNamespace, nodeName)
-				createMachine(testMachine)
-			})
+					testNode.Status.Conditions = []corev1.NodeCondition{*existingCondition}
+				})
 
-			It("should not return an error", func() {
-				Expect(err).ToNot(HaveOccurred())
-			})
-
-			It("should return a machine", func() {
-				Expect(machine).To(Equal(testMachine))
+				It("should not modify the existing conditions", func() {
+					Expect(testNode.Status.Conditions).To(HaveLen(2))
+					Expect(testNode.Status.Conditions).To(ContainElement(Equal(*existingCondition)))
+				})
 			})
 		})
 	})
@@ -303,17 +335,17 @@ func isClosed(ch <-chan struct{}) bool {
 	return false
 }
 
-func deleteAllMachines(c client.Client) error {
-	machineList := &machinev1.MachineList{}
-	err := c.List(ctx, machineList)
+func deleteAllNodes(c client.Client) error {
+	nodeList := &corev1.NodeList{}
+	err := c.List(ctx, nodeList)
 	if err != nil {
 		return fmt.Errorf("error listing machines: %v", err)
 	}
 
-	// Delete all machines found
-	for _, machine := range machineList.Items {
-		m := machine
-		err := c.Delete(ctx, &m)
+	// Delete all nodes found
+	for _, node := range nodeList.Items {
+		n := node
+		err := c.Delete(ctx, &n)
 		if err != nil {
 			return err
 		}
@@ -321,34 +353,28 @@ func deleteAllMachines(c client.Client) error {
 	return nil
 }
 
-func newTestMachine(name, namespace, nodeName string) *machinev1.Machine {
-	return &machinev1.Machine{
+func newTestNode(name string) *corev1.Node {
+	return &corev1.Node{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "Machine",
-			APIVersion: machinev1.SchemeGroupVersion.String(),
+			Kind:       "Node",
+			APIVersion: "",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Status: machinev1.MachineStatus{
-			NodeRef: &corev1.ObjectReference{
-				Name: nodeName,
-			},
+			Name: name,
 		},
 	}
 }
 
-func createMachine(m *machinev1.Machine) {
-	typeMeta := m.TypeMeta
-	status := m.Status
-	Expect(k8sClient.Create(ctx, m)).To(Succeed())
-	m.Status = status
-	Expect(k8sClient.Status().Update(ctx, m)).To(Succeed())
+func createNode(n *corev1.Node) {
+	typeMeta := n.TypeMeta
+	status := n.Status
+	Expect(k8sClient.Create(ctx, n)).To(Succeed())
+	n.Status = status
+	Expect(k8sClient.Status().Update(ctx, n)).To(Succeed())
 
 	// Fetch object to sync back to latest changes
-	key := client.ObjectKey{Namespace: m.Namespace, Name: m.Name}
-	Expect(k8sClient.Get(ctx, key, m)).To(Succeed())
+	key := client.ObjectKey{Namespace: n.Namespace, Name: n.Name}
+	Expect(k8sClient.Get(ctx, key, n)).To(Succeed())
 	// Restore TypeMeta as not restored by Get
-	m.TypeMeta = typeMeta
+	n.TypeMeta = typeMeta
 }

--- a/pkg/termination/termination_suite_test.go
+++ b/pkg/termination/termination_suite_test.go
@@ -22,8 +22,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -33,8 +31,7 @@ import (
 )
 
 const (
-	timeout       = 10 * time.Second
-	testNamespace = "test-namespace"
+	timeout = 10 * time.Second
 )
 
 var (
@@ -71,12 +68,6 @@ var _ = BeforeSuite(func() {
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	Expect(err).ToNot(HaveOccurred())
-
-	Expect(k8sClient.Create(ctx, &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: testNamespace,
-		},
-	})).To(Succeed())
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
Switch from deleting the Machine to marking the Node with a `Terminating` condition.
This will integrate with an MHC to ensure that the Machine is deleted.
This should be possible using the Node's credentials and as such, the termination handler will not need its own credentials and extra permissions.

Requires https://github.com/openshift/machine-api-operator/pull/627 before it will work