### PR TITLE
Remove verify-actuator-pkg.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,11 +80,7 @@ push:
 	docker push "$(IMAGE):$(MUTABLE_TAG)"
 
 .PHONY: check
-check: fmt vet lint test check-pkg ## Check your code
-
-.PHONY: check-pkg
-check-pkg:
-	./hack/verify-actuator-pkg.sh
+check: fmt vet lint test ## Check your code
 
 .PHONY: unit
 unit: # Run unit test

--- a/hack/verify-actuator-pkg.sh
+++ b/hack/verify-actuator-pkg.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -e
-
-go get -mod=readonly -u github.com/openshift/cluster-api-actuator-pkg
-exec git diff --exit-code


### PR DESCRIPTION
CI stopped using it almost 1 year ago since
https://github.com/openshift/release/pull/4060/commits/cd154392fad5bb511