### PR TITLE
Bug 1857175: Revendor mao to bring https://github.com/openshift/machine-api-operator/pull/644

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,7 @@ require (
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.8.1
 	github.com/openshift/api v0.0.0-20200424083944-0422dc17083e
-	github.com/openshift/machine-api-operator v0.2.1-0.20200701225707-950912b03628
-	golang.org/x/text v0.3.3 // indirect
+	github.com/openshift/machine-api-operator v0.2.1-0.20200722104429-f4f9b84df9b7
 
 	// kube 1.18
 	k8s.io/api v0.18.2

--- a/go.sum
+++ b/go.sum
@@ -347,11 +347,15 @@ github.com/openshift/cluster-api-provider-azure v0.1.0-alpha.3.0.20200618001858-
 github.com/openshift/cluster-api-provider-azure v0.1.0-alpha.3.0.20200618001858-af08a66b92de/go.mod h1:XTKOAoCAzFtgljQ9HUs4KeTyczeFUoXa0S9+0R2WCmk=
 github.com/openshift/cluster-api-provider-gcp v0.0.1-0.20200701112720-3a7d727c9a10 h1:AZczulAAkBuMm058BGtk5id9lhupszVQXvZFdKmSHEE=
 github.com/openshift/cluster-api-provider-gcp v0.0.1-0.20200701112720-3a7d727c9a10/go.mod h1:wgkZrOlcIMWTzo8khB4Js2PoDJDlIUUdzCBm7BuDdqw=
+github.com/openshift/cluster-api-provider-gcp v0.0.1-0.20200713133651-5c8a640669ac h1:j4kWMuCD5Yvwa3LDXy0tN0ys24jDbQnQbCl0oRTBb6I=
+github.com/openshift/cluster-api-provider-gcp v0.0.1-0.20200713133651-5c8a640669ac/go.mod h1:XVYX9JE339nKbDDa/W481XD+1GTeqeaBm8bDPr7WE7I=
 github.com/openshift/library-go v0.0.0-20200512120242-21a1ff978534/go.mod h1:2kWwXTkpoQJUN3jZ3QW88EIY1hdRMqxgRs2hheEW/pg=
 github.com/openshift/machine-api-operator v0.2.1-0.20200527204437-14e5e0c7d862/go.mod h1:YKEQMHjXzrzm4fQGTyHBafFfQ/Yq/FrV+1YcGdPCp+0=
 github.com/openshift/machine-api-operator v0.2.1-0.20200611014855-9a69f85c32dd/go.mod h1:6vMi+R3xqznBdq5rgeal9N3ak3sOpy50t0fdRCcQXjE=
 github.com/openshift/machine-api-operator v0.2.1-0.20200701225707-950912b03628 h1:8ErZADoEg3XJBqY8tM9eUEJ9szb7jQHNHSlw2j9Gr5Y=
 github.com/openshift/machine-api-operator v0.2.1-0.20200701225707-950912b03628/go.mod h1:cxjy/RUzv5C2T5FNl1KKXUgtakWsezWQ642B/CD9VQA=
+github.com/openshift/machine-api-operator v0.2.1-0.20200722104429-f4f9b84df9b7 h1:jeLZ5Ng+Ri42dbZveN1ofrrRsUnYusauzeXPDTnXQfE=
+github.com/openshift/machine-api-operator v0.2.1-0.20200722104429-f4f9b84df9b7/go.mod h1:XDsNRAVEJtkI00e51SAZ/PnqNJl1zv0rHXSdl9L1oOY=
 github.com/operator-framework/operator-sdk v0.5.1-0.20190301204940-c2efe6f74e7b/go.mod h1:iVyukRkam5JZa8AnjYf+/G3rk7JI1+M6GsU0sq0B9NA=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/vendor/github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1/machine_types.go
+++ b/vendor/github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1/machine_types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1beta1
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -194,8 +196,13 @@ type LastOperation struct {
 func (m *Machine) Validate() field.ErrorList {
 	errors := field.ErrorList{}
 
-	// validate provider config is set
+	// validate spec.labels
 	fldPath := field.NewPath("spec")
+	if m.Labels[MachineClusterIDLabel] == "" {
+		errors = append(errors, field.Invalid(fldPath.Child("labels"), m.Labels, fmt.Sprintf("missing %v label.", MachineClusterIDLabel)))
+	}
+
+	// validate provider config is set
 	if m.Spec.ProviderSpec.Value == nil {
 		errors = append(errors, field.Invalid(fldPath.Child("spec").Child("providerspec"), m.Spec.ProviderSpec, "value field must be set"))
 	}

--- a/vendor/github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1/machineset_webhook.go
+++ b/vendor/github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1/machineset_webhook.go
@@ -124,6 +124,20 @@ func (h *machineSetDefaulterHandler) defaultMachineSet(ms *MachineSet) (bool, ut
 	if ok, err := h.webhookOperations(m, h.clusterID); !ok {
 		errs = append(errs, err.Errors()...)
 	} else {
+		// Enforce that the same clusterID is set for machineSet Selector and machine labels.
+		// Otherwise a discrepancy on the value would leave the machine orphan
+		// and would trigger a new machine creation by the machineSet.
+		// https://bugzilla.redhat.com/show_bug.cgi?id=1857175
+		if ms.Spec.Selector.MatchLabels == nil {
+			ms.Spec.Selector.MatchLabels = make(map[string]string)
+		}
+		ms.Spec.Selector.MatchLabels[MachineClusterIDLabel] = h.clusterID
+
+		if ms.Spec.Template.Labels == nil {
+			ms.Spec.Template.Labels = make(map[string]string)
+		}
+		ms.Spec.Template.Labels[MachineClusterIDLabel] = h.clusterID
+
 		// Restore the defaulted template
 		ms.Spec.Template.Spec = m.Spec
 	}

--- a/vendor/github.com/openshift/machine-api-operator/pkg/controller/machine/controller.go
+++ b/vendor/github.com/openshift/machine-api-operator/pkg/controller/machine/controller.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"time"
 
-	configv1 "github.com/openshift/api/config/v1"
 	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	"github.com/openshift/machine-api-operator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
@@ -92,8 +91,6 @@ const (
 	unknownInstanceState = "Unknown"
 
 	skipWaitForDeleteTimeoutSeconds = 60 * 5
-
-	globalInfrastuctureName = "cluster"
 )
 
 var DefaultActuator Actuator
@@ -175,11 +172,6 @@ func (r *ReconcileMachine) Reconcile(request reconcile.Request) (reconcile.Resul
 		err := fmt.Errorf("%v: machine validation failed: %v", machineName, errList.ToAggregate().Error())
 		klog.Error(err)
 		r.eventRecorder.Eventf(m, corev1.EventTypeWarning, "FailedValidate", err.Error())
-		return reconcile.Result{}, err
-	}
-
-	// Add clusterID label
-	if err := r.setClusterIDLabel(ctx, m); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -467,25 +459,6 @@ func (r *ReconcileMachine) patchFailedMachineInstanceAnnotation(machine *machine
 	if err := r.Client.Patch(context.Background(), machine, baseToPatch); err != nil {
 		return err
 	}
-	return nil
-}
-
-func (r *ReconcileMachine) setClusterIDLabel(ctx context.Context, m *machinev1.Machine) error {
-	infra := &configv1.Infrastructure{}
-	infraName := client.ObjectKey{Name: globalInfrastuctureName}
-
-	if err := r.Client.Get(ctx, infraName, infra); err != nil {
-		return err
-	}
-
-	clusterID := infra.Status.InfrastructureName
-
-	if m.Labels == nil {
-		m.Labels = make(map[string]string)
-	}
-
-	m.Labels[machinev1.MachineClusterIDLabel] = clusterID
-
 	return nil
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -192,9 +192,9 @@ github.com/openshift/api/config/v1
 github.com/openshift/client-go/config/clientset/versioned
 github.com/openshift/client-go/config/clientset/versioned/scheme
 github.com/openshift/client-go/config/clientset/versioned/typed/config/v1
-# github.com/openshift/cluster-api-provider-gcp v0.0.1-0.20200701112720-3a7d727c9a10
+# github.com/openshift/cluster-api-provider-gcp v0.0.1-0.20200713133651-5c8a640669ac
 github.com/openshift/cluster-api-provider-gcp/pkg/apis/gcpprovider/v1beta1
-# github.com/openshift/machine-api-operator v0.2.1-0.20200701225707-950912b03628
+# github.com/openshift/machine-api-operator v0.2.1-0.20200722104429-f4f9b84df9b7
 github.com/openshift/machine-api-operator/pkg/apis/machine
 github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1
 github.com/openshift/machine-api-operator/pkg/apis/vsphereprovider/v1beta1


### PR DESCRIPTION
This is to bring https://github.com/openshift/machine-api-operator/pull/644 and so restoring the previous backend behaviour in the machine controller https://github.com/openshift/machine-api-operator/pull/644/commits/261c3373e317fe3c9736d48c1deb96b87be8f492
