### PR TITLE
Bug 1864352: Add leader election mechanism to release 4.5

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -35,15 +35,41 @@ import (
 )
 
 func main() {
-	var printVersion bool
-	flag.BoolVar(&printVersion, "version", false, "print version and exit")
+	printVersion := flag.Bool(
+		"version",
+		false,
+		"print version and exit",
+	)
+
+	watchNamespace := flag.String(
+		"namespace",
+		"",
+		"Namespace that the controller watches to reconcile machine-api objects. If unspecified, the controller watches for machine-api objects across all namespaces.",
+	)
+
+	leaderElectResourceNamespace := flag.String(
+		"leader-elect-resource-namespace",
+		"",
+		"The namespace of resource object that is used for locking during leader election. If unspecified and running in cluster, defaults to the service account namespace for the controller. Required for leader-election outside of a cluster.",
+	)
+
+	leaderElect := flag.Bool(
+		"leader-elect",
+		false,
+		"Start a leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability.",
+	)
+
+	leaderElectLeaseDuration := flag.Duration(
+		"leader-elect-lease-duration",
+		15*time.Second,
+		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.",
+	)
 
 	klog.InitFlags(nil)
-	watchNamespace := flag.String("namespace", "", "Namespace that the controller watches to reconcile machine-api objects. If unspecified, the controller watches for machine-api objects across all namespaces.")
 	flag.Set("logtostderr", "true")
 	flag.Parse()
 
-	if printVersion {
+	if *printVersion {
 		fmt.Println(version.String)
 		os.Exit(0)
 	}
@@ -57,10 +83,15 @@ func main() {
 	// Setup a Manager
 	syncPeriod := 10 * time.Minute
 	opts := manager.Options{
-		SyncPeriod: &syncPeriod,
+		LeaderElection:          *leaderElect,
+		LeaderElectionNamespace: *leaderElectResourceNamespace,
+		LeaderElectionID:        "cluster-api-provider-aws-leader",
+		LeaseDuration:           leaderElectLeaseDuration,
+		SyncPeriod:              &syncPeriod,
 		// Disable metrics serving
 		MetricsBindAddress: "0",
 	}
+
 	if *watchNamespace != "" {
 		opts.Namespace = *watchNamespace
 		klog.Infof("Watching machine-api objects only in namespace %q for reconciliation.", opts.Namespace)

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -61,7 +61,7 @@ func main() {
 
 	leaderElectLeaseDuration := flag.Duration(
 		"leader-elect-lease-duration",
-		15*time.Second,
+		90*time.Second,
 		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.",
 	)
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -34,6 +34,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
+// The default durations for the leader electrion operations.
+var (
+	leaseDuration = 120 * time.Second
+	renewDealine  = 110 * time.Second
+	retryPeriod   = 20 * time.Second
+)
+
 func main() {
 	printVersion := flag.Bool(
 		"version",
@@ -61,7 +68,7 @@ func main() {
 
 	leaderElectLeaseDuration := flag.Duration(
 		"leader-elect-lease-duration",
-		90*time.Second,
+		leaseDuration,
 		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.",
 	)
 
@@ -90,6 +97,9 @@ func main() {
 		SyncPeriod:              &syncPeriod,
 		// Disable metrics serving
 		MetricsBindAddress: "0",
+		// Slow the default retry and renew election rate to reduce etcd writes at idle: BZ 1858400
+		RetryPeriod:   &retryPeriod,
+		RenewDeadline: &renewDealine,
 	}
 
 	if *watchNamespace != "" {


### PR DESCRIPTION
This change brings in 3 cherry-pick commits which add leader election to these controllers.

4bfda8a1daeb973152d9ff903f6c683db6a9fd7d
dafb3ff392f1a9def754f3cc60179acb6f650011
7ccf74933b75106c666865a1c7ff01fd84054e94