### PR TITLE
Bug 1872080: Add Dockerfile.rhel to match build configuration in ocp-build-data

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,0 +1,10 @@
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-4.6 AS builder
+WORKDIR /go/src/sigs.k8s.io/cluster-api-provider-aws
+COPY . .
+# VERSION env gets set in the openshift/release image and refers to the golang version, which interfers with our own
+RUN unset VERSION \
+ && GOPROXY=off NO_DOCKER=1 make build
+
+FROM registry.svc.ci.openshift.org/ocp/4.6:base
+COPY --from=builder /go/src/sigs.k8s.io/cluster-api-provider-aws/bin/machine-controller-manager /
+COPY --from=builder /go/src/sigs.k8s.io/cluster-api-provider-aws/bin/termination-handler /


### PR DESCRIPTION
This change adds a new Dockerfile.rhel file to control builds that
target rhel. It is inspired by the automatically generated patches which
ensure that build files match what is in the
[ocp-build-data
repository](https://github.com/openshift/ocp-build-data/tree/openshift-4.6-rhel-8/images)
used for producing release artifacts.

After this change merges, the configuration files in
https://github.com/openshift/release/blob/master/ci-operator/config/openshift/cluster-api-provider-aws/openshift-cluster-api-provider-aws-master.yaml
and
https://github.com/openshift/ocp-build-data/blob/openshift-4.6/images/ose-aws-machine-controllers.yml
should be updated with the new dockerfile path.