### PR TITLE
add bugzilla component and subcomponent to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,3 +1,5 @@
+component: "Cloud Compute"
+subcomponent: "Other Providers"
 approvers:
   - enxebre
   - michaelgugino


### PR DESCRIPTION
This change adds the bugzilla component and subcomponent names to the OWNERS file to
comply with the prodsec requirements for OpenShift builds through ART.