### PR TITLE
Fix termination unsupported scheme test

### DIFF
--- a/pkg/termination/handler_test.go
+++ b/pkg/termination/handler_test.go
@@ -209,7 +209,7 @@ var _ = Describe("Handler Suite", func() {
 				})
 
 				It("should return an error", func() {
-					Eventually(errs).Should(Receive(MatchError("error polling termination endpoint: could not get URL \"abc#1://localhost\": Get abc#1://localhost: unsupported protocol scheme \"\"")))
+					Eventually(errs).Should(Receive(MatchError("error polling termination endpoint: could not get URL \"abc#1://localhost\": Get \"abc#1://localhost\": unsupported protocol scheme \"\"")))
 				})
 
 				It("should not delete the machine", func() {


### PR DESCRIPTION
The error message coming out of the URL package has changed between 1.14 and 1.15. The unit test was not updated to account for this change when the scripts were upgraded. This should resolve existing unit testing issues in 1.15.

This unit test was illegitimately blocking #374 from merging, this should resolve that issue.