### PR TITLE
Bug 1907286: Ensure Machine is marked interruptible as well as Node

### DIFF
--- a/pkg/actuators/machine/reconciler.go
+++ b/pkg/actuators/machine/reconciler.go
@@ -372,6 +372,8 @@ func (r *Reconciler) setMachineCloudProviderSpecifics(instance *ec2.Instance) er
 	}
 
 	if instance.InstanceLifecycle != nil && *instance.InstanceLifecycle == ec2.InstanceLifecycleTypeSpot {
+		// Label on the Machine so that an MHC can select spot instances
+		r.machine.Labels[machinecontroller.MachineInterruptibleInstanceLabelName] = ""
 		// Label on the Spec so that it is propogated to the Node
 		r.machine.Spec.Labels[machinecontroller.MachineInterruptibleInstanceLabelName] = ""
 	}


### PR DESCRIPTION
To enable the termination handler MHC to work, we need to label the Machine as well as the Node as interruptible.