### PR TITLE
Bug 1906740: Ensure the region is valid when creating AWS client

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -140,7 +140,7 @@ func main() {
 	machineActuator := machineactuator.NewActuator(machineactuator.ActuatorParams{
 		Client:           mgr.GetClient(),
 		EventRecorder:    mgr.GetEventRecorderFor("awscontroller"),
-		AwsClientBuilder: awsclient.NewClient,
+		AwsClientBuilder: awsclient.NewValidatedClient,
 	})
 
 	if err := machine.AddWithActuator(mgr, machineActuator); err != nil {


### PR DESCRIPTION
This PR ensures that any time we create a client, if the endpoint doesn't resolve to a known standard or custom endpoint, the error returned is an AWS `endpoints.UknownEndpointError` instead of a request error.

Currently, the endpoint resolver falls back to constructing an invalid URL when it doesn't know a particular region, this results in request being made and the error returning looking like `Request Error: Unable to resolve host:...`, now the error will correctly be wrapped such that is says `region "foo" not resolved: Unknown Endpoint: ...` which should hopefully narrow down that the issue is a user input error faster.

This doesn't fully resolve the attached bug but will improve the error message to help towards a resolution.