### PR TITLE
Bug 1915114: use separate client for accessing openshift-config-managed namespace

### DIFF
--- a/pkg/actuators/machine/actuator.go
+++ b/pkg/actuators/machine/actuator.go
@@ -39,24 +39,27 @@ const (
 
 // Actuator is responsible for performing machine reconciliation.
 type Actuator struct {
-	client           runtimeclient.Client
-	eventRecorder    record.EventRecorder
-	awsClientBuilder awsclient.AwsClientBuilderFuncType
+	client              runtimeclient.Client
+	eventRecorder       record.EventRecorder
+	awsClientBuilder    awsclient.AwsClientBuilderFuncType
+	configManagedClient runtimeclient.Client
 }
 
 // ActuatorParams holds parameter information for Actuator.
 type ActuatorParams struct {
-	Client           runtimeclient.Client
-	EventRecorder    record.EventRecorder
-	AwsClientBuilder awsclient.AwsClientBuilderFuncType
+	Client              runtimeclient.Client
+	EventRecorder       record.EventRecorder
+	AwsClientBuilder    awsclient.AwsClientBuilderFuncType
+	ConfigManagedClient runtimeclient.Client
 }
 
 // NewActuator returns an actuator.
 func NewActuator(params ActuatorParams) *Actuator {
 	return &Actuator{
-		client:           params.Client,
-		eventRecorder:    params.EventRecorder,
-		awsClientBuilder: params.AwsClientBuilder,
+		client:              params.Client,
+		eventRecorder:       params.EventRecorder,
+		awsClientBuilder:    params.AwsClientBuilder,
+		configManagedClient: params.ConfigManagedClient,
 	}
 }
 
@@ -74,10 +77,11 @@ func (a *Actuator) handleMachineError(machine *machinev1.Machine, err error, eve
 func (a *Actuator) Create(ctx context.Context, machine *machinev1.Machine) error {
 	klog.Infof("%s: actuator creating machine", machine.GetName())
 	scope, err := newMachineScope(machineScopeParams{
-		Context:          ctx,
-		client:           a.client,
-		machine:          machine,
-		awsClientBuilder: a.awsClientBuilder,
+		Context:             ctx,
+		client:              a.client,
+		machine:             machine,
+		awsClientBuilder:    a.awsClientBuilder,
+		configManagedClient: a.configManagedClient,
 	})
 	if err != nil {
 		fmtErr := fmt.Errorf(scopeFailFmt, machine.GetName(), err)
@@ -99,10 +103,11 @@ func (a *Actuator) Create(ctx context.Context, machine *machinev1.Machine) error
 func (a *Actuator) Exists(ctx context.Context, machine *machinev1.Machine) (bool, error) {
 	klog.Infof("%s: actuator checking if machine exists", machine.GetName())
 	scope, err := newMachineScope(machineScopeParams{
-		Context:          ctx,
-		client:           a.client,
-		machine:          machine,
-		awsClientBuilder: a.awsClientBuilder,
+		Context:             ctx,
+		client:              a.client,
+		machine:             machine,
+		awsClientBuilder:    a.awsClientBuilder,
+		configManagedClient: a.configManagedClient,
 	})
 	if err != nil {
 		return false, fmt.Errorf(scopeFailFmt, machine.GetName(), err)
@@ -114,10 +119,11 @@ func (a *Actuator) Exists(ctx context.Context, machine *machinev1.Machine) (bool
 func (a *Actuator) Update(ctx context.Context, machine *machinev1.Machine) error {
 	klog.Infof("%s: actuator updating machine", machine.GetName())
 	scope, err := newMachineScope(machineScopeParams{
-		Context:          ctx,
-		client:           a.client,
-		machine:          machine,
-		awsClientBuilder: a.awsClientBuilder,
+		Context:             ctx,
+		client:              a.client,
+		machine:             machine,
+		awsClientBuilder:    a.awsClientBuilder,
+		configManagedClient: a.configManagedClient,
 	})
 	if err != nil {
 		fmtErr := fmt.Errorf(scopeFailFmt, machine.GetName(), err)
@@ -152,10 +158,11 @@ func (a *Actuator) Update(ctx context.Context, machine *machinev1.Machine) error
 func (a *Actuator) Delete(ctx context.Context, machine *machinev1.Machine) error {
 	klog.Infof("%s: actuator deleting machine", machine.GetName())
 	scope, err := newMachineScope(machineScopeParams{
-		Context:          ctx,
-		client:           a.client,
-		machine:          machine,
-		awsClientBuilder: a.awsClientBuilder,
+		Context:             ctx,
+		client:              a.client,
+		machine:             machine,
+		awsClientBuilder:    a.awsClientBuilder,
+		configManagedClient: a.configManagedClient,
 	})
 	if err != nil {
 		fmtErr := fmt.Errorf(scopeFailFmt, machine.GetName(), err)

--- a/pkg/actuators/machine/actuator_test.go
+++ b/pkg/actuators/machine/actuator_test.go
@@ -154,11 +154,11 @@ func TestMachineEvents(t *testing.T) {
 
 			mockCtrl := gomock.NewController(t)
 			mockAWSClient := mockaws.NewMockClient(mockCtrl)
-			awsClientBuilder := func(client runtimeclient.Client, secretName, namespace, region string) (awsclient.Client, error) {
+			awsClientBuilder := func(client runtimeclient.Client, secretName, namespace, region string, configManagedClient runtimeclient.Client) (awsclient.Client, error) {
 				return mockAWSClient, nil
 			}
 			if tc.invalidMachineScope {
-				awsClientBuilder = func(client runtimeclient.Client, secretName, namespace, region string) (awsclient.Client, error) {
+				awsClientBuilder = func(client runtimeclient.Client, secretName, namespace, region string, configManagedClient runtimeclient.Client) (awsclient.Client, error) {
 					return nil, errors.New("AWS client error")
 				}
 			}

--- a/pkg/actuators/machine/machine_scope.go
+++ b/pkg/actuators/machine/machine_scope.go
@@ -31,6 +31,8 @@ type machineScopeParams struct {
 	client runtimeclient.Client
 	// machine resource
 	machine *machinev1.Machine
+	// api server controller runtime client for the openshift-config-managed namespace
+	configManagedClient runtimeclient.Client
 }
 
 type machineScope struct {
@@ -63,7 +65,7 @@ func newMachineScope(params machineScopeParams) (*machineScope, error) {
 		credentialsSecretName = providerSpec.CredentialsSecret.Name
 	}
 
-	awsClient, err := params.awsClientBuilder(params.client, credentialsSecretName, params.machine.Namespace, providerSpec.Placement.Region)
+	awsClient, err := params.awsClientBuilder(params.client, credentialsSecretName, params.machine.Namespace, providerSpec.Placement.Region, params.configManagedClient)
 	if err != nil {
 		return nil, machineapierros.InvalidMachineConfiguration("failed to create aws client: %v", err.Error())
 	}

--- a/pkg/actuators/machine/machine_scope_test.go
+++ b/pkg/actuators/machine/machine_scope_test.go
@@ -261,7 +261,7 @@ func TestPatchMachine(t *testing.T) {
 			machineScope, err := newMachineScope(machineScopeParams{
 				client:  k8sClient,
 				machine: machine,
-				awsClientBuilder: func(client runtimeclient.Client, secretName, namespace, region string) (awsclient.Client, error) {
+				awsClientBuilder: func(client runtimeclient.Client, secretName, namespace, region string, configManagedClient runtimeclient.Client) (awsclient.Client, error) {
 					return nil, nil
 				},
 			})

--- a/pkg/actuators/machine/reconciler_test.go
+++ b/pkg/actuators/machine/reconciler_test.go
@@ -89,7 +89,7 @@ func TestAvailabilityZone(t *testing.T) {
 			machineScope, err := newMachineScope(machineScopeParams{
 				client:  fakeClient,
 				machine: machine,
-				awsClientBuilder: func(client runtimeclient.Client, secretName, namespace, region string) (awsclient.Client, error) {
+				awsClientBuilder: func(client runtimeclient.Client, secretName, namespace, region string, configManagedClient runtimeclient.Client) (awsclient.Client, error) {
 					return mockAWSClient, nil
 				},
 			})
@@ -492,7 +492,7 @@ func TestCreate(t *testing.T) {
 		machineScope, err := newMachineScope(machineScopeParams{
 			client:  fakeClient,
 			machine: machine,
-			awsClientBuilder: func(client runtimeclient.Client, secretName, namespace, region string) (awsclient.Client, error) {
+			awsClientBuilder: func(client runtimeclient.Client, secretName, namespace, region string, configManagedClient runtimeclient.Client) (awsclient.Client, error) {
 				return mockAWSClient, nil
 			},
 		})
@@ -638,7 +638,7 @@ func TestGetMachineInstances(t *testing.T) {
 			machineScope, err := newMachineScope(machineScopeParams{
 				client:  fakeClient,
 				machine: machineCopy,
-				awsClientBuilder: func(client runtimeclient.Client, secretName, namespace, region string) (awsclient.Client, error) {
+				awsClientBuilder: func(client runtimeclient.Client, secretName, namespace, region string, configManagedClient runtimeclient.Client) (awsclient.Client, error) {
 					return mockAWSClient, nil
 				},
 			})


### PR DESCRIPTION
The controller-runtime client that is create with the manager only has access to objects in the openshift-machine-api namespace. Consequently, attempts to fetch the kube-cloud-config ConfigMap from the openshift-config-managed namespace using that client return NotFound. These changes create a new, additional client limited to the openshift-config-managed namespace and plumb the new client through to where it is needed for fetching the custom CA bundle.