### PR TITLE
Bug 1934021: Ensure response body is closed when we are finished with the request

### DIFF
--- a/pkg/termination/handler.go
+++ b/pkg/termination/handler.go
@@ -96,6 +96,9 @@ func (h *handler) run(ctx context.Context, wg *sync.WaitGroup) error {
 
 	if err := wait.PollImmediateUntil(h.pollInterval, func() (bool, error) {
 		resp, err := http.Get(h.pollURL.String())
+		if resp != nil {
+			defer resp.Body.Close()
+		}
 		if err != nil {
 			return false, fmt.Errorf("could not get URL %q: %v", h.pollURL.String(), err)
 		}


### PR DESCRIPTION
When creating an http request in go, this sets two goroutines in the background running. If the body is not closed properly, these goroutines are leaked. This leads to a gradual increase in memory used by the application over time. We must ensure we always close response bodies