### PR TITLE
Bug 1952611: [OCPCLOUD-1115] Get instance tags from infrastructure object

### DIFF
--- a/pkg/actuators/machine/suite_test.go
+++ b/pkg/actuators/machine/suite_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -26,8 +27,13 @@ var (
 
 func TestMain(m *testing.M) {
 	testEnv := &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crds")},
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "..", "config", "crds"),
+			filepath.Join("..", "..", "..", "vendor", "github.com", "openshift", "api", "config", "v1"),
+		},
 	}
+
+	configv1.AddToScheme(scheme.Scheme)
 
 	cfg, err := testEnv.Start()
 	if err != nil {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -53,8 +53,8 @@ const (
 	// AwsCredsSecretAccessKey is secret key containing AWS Secret Key
 	AwsCredsSecretAccessKey = "aws_secret_access_key"
 
-	// globalInfrastuctureName default name for infrastructure object
-	globalInfrastuctureName = "cluster"
+	// GlobalInfrastuctureName default name for infrastructure object
+	GlobalInfrastuctureName = "cluster"
 
 	// KubeCloudConfigNamespace is the namespace where the kube cloud config ConfigMap is located
 	KubeCloudConfigNamespace = "openshift-config-managed"
@@ -283,7 +283,7 @@ var addProviderVersionToUserAgent = request.NamedHandler{
 
 func resolveEndpoints(awsConfig *aws.Config, ctrlRuntimeClient client.Client, region string) error {
 	infra := &configv1.Infrastructure{}
-	infraName := client.ObjectKey{Name: globalInfrastuctureName}
+	infraName := client.ObjectKey{Name: GlobalInfrastuctureName}
 
 	if err := ctrlRuntimeClient.Get(context.Background(), infraName, infra); err != nil {
 		return err


### PR DESCRIPTION
Get instance tags from infrastructure objects. Tags that come from the infra object have precedence over providerSpec.

Related enhancements: https://github.com/openshift/enhancements/pull/706