### PR TITLE
Bug 1925276:  Fix eventual consistency logic to be consistent 

### DIFF
--- a/pkg/actuators/machine/reconciler.go
+++ b/pkg/actuators/machine/reconciler.go
@@ -103,7 +103,7 @@ func (r *Reconciler) create() error {
 
 	r.machineScope.setProviderStatus(instance, conditionSuccess())
 
-	return r.requeueIfInstancePending(instance)
+	return nil
 }
 
 // delete deletes machine
@@ -181,7 +181,7 @@ func (r *Reconciler) update() error {
 
 	existingLen := len(existingInstances)
 	if existingLen == 0 {
-		if r.machine.Spec.ProviderID != nil && *r.machine.Spec.ProviderID != "" && (r.machine.Status.LastUpdated == nil || r.machine.Status.LastUpdated.Add(requeueAfterSeconds*time.Second).After(time.Now())) {
+		if r.machine.Spec.ProviderID != nil && *r.machine.Spec.ProviderID != "" && len(r.machine.Status.Addresses) == 0 {
 			klog.Infof("%s: Possible eventual-consistency discrepancy; returning an error to requeue", r.machine.Name)
 			return &machinecontroller.RequeueAfterError{RequeueAfter: requeueAfterSeconds * time.Second}
 		}
@@ -257,7 +257,7 @@ func (r *Reconciler) exists() (bool, error) {
 	}
 
 	if len(existingInstances) == 0 {
-		if r.machine.Spec.ProviderID != nil && *r.machine.Spec.ProviderID != "" && (r.machine.Status.LastUpdated == nil || r.machine.Status.LastUpdated.Add(requeueAfterSeconds*time.Second).After(time.Now())) {
+		if r.machine.Spec.ProviderID != nil && *r.machine.Spec.ProviderID != "" && len(r.machine.Status.Addresses) == 0 {
 			klog.Infof("%s: Possible eventual-consistency discrepancy; returning an error to requeue", r.machine.Name)
 			return false, &machinecontroller.RequeueAfterError{RequeueAfter: requeueAfterSeconds * time.Second}
 		}

--- a/pkg/actuators/machine/stubs.go
+++ b/pkg/actuators/machine/stubs.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elbv2"
+	configv1 "github.com/openshift/api/config/v1"
 	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	machinecontroller "github.com/openshift/machine-api-operator/pkg/controller/machine"
 	corev1 "k8s.io/api/core/v1"
@@ -270,7 +271,7 @@ func stubReservation(imageID, instanceID string, privateIP string) *ec2.Reservat
 				ImageId:    aws.String(imageID),
 				InstanceId: aws.String(instanceID),
 				State: &ec2.InstanceState{
-					Name: aws.String(ec2.InstanceStateNameRunning),
+					Name: aws.String(ec2.InstanceStateNamePending),
 					Code: aws.Int64(16),
 				},
 				LaunchTime: aws.Time(time.Now()),
@@ -330,4 +331,12 @@ func StubDescribeVPCs() (*ec2.DescribeVpcsOutput, error) {
 			},
 		},
 	}, nil
+}
+
+func stubInfraObject() *configv1.Infrastructure {
+	return &configv1.Infrastructure{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: awsclient.GlobalInfrastuctureName,
+		},
+	}
 }


### PR DESCRIPTION
Based on:  https://github.com/openshift/cluster-api-provider-aws/pull/384

> Eventual consistency logic is not aligned with
> MAO after phases were added. This is causing
> some machines to go failed when they shouldn't.
> 
> This commit also removes the error after create
> as it is no longer useful. We manipulate the
> machine-object and status, so the next request
> will be requeued and our delay attempt is ignored.
> 
