### PR TITLE
Bug 1965080: Reduce frequency of calls to register targets with load balancers

### DIFF
--- a/pkg/actuators/machine/actuator_test.go
+++ b/pkg/actuators/machine/actuator_test.go
@@ -176,10 +176,10 @@ func TestMachineEvents(t *testing.T) {
 			if tc.awsError {
 				mockAWSClient.EXPECT().DescribeInstances(gomock.Any()).Return(nil, errors.New("AWS error")).AnyTimes()
 			} else {
-				mockAWSClient.EXPECT().DescribeInstances(gomock.Any()).Return(stubDescribeInstancesOutput("ami-a9acbbd6", "i-02fcb933c5da7085c", ec2.InstanceStateNameRunning), nil).AnyTimes()
+				mockAWSClient.EXPECT().DescribeInstances(gomock.Any()).Return(stubDescribeInstancesOutput("ami-a9acbbd6", "i-02fcb933c5da7085c", ec2.InstanceStateNameRunning, "192.168.0.10"), nil).AnyTimes()
 			}
 
-			mockAWSClient.EXPECT().RunInstances(gomock.Any()).Return(stubReservation("ami-a9acbbd6", "i-02fcb933c5da7085c"), nil).AnyTimes()
+			mockAWSClient.EXPECT().RunInstances(gomock.Any()).Return(stubReservation("ami-a9acbbd6", "i-02fcb933c5da7085c", "192.168.0.10"), nil).AnyTimes()
 			mockAWSClient.EXPECT().TerminateInstances(gomock.Any()).Return(&ec2.TerminateInstancesOutput{}, nil)
 			mockAWSClient.EXPECT().RegisterInstancesWithLoadBalancer(gomock.Any()).Return(nil, nil).AnyTimes()
 			mockAWSClient.EXPECT().TerminateInstances(gomock.Any()).Return(&ec2.TerminateInstancesOutput{}, nil).AnyTimes()
@@ -187,6 +187,8 @@ func TestMachineEvents(t *testing.T) {
 			mockAWSClient.EXPECT().ELBv2DescribeLoadBalancers(gomock.Any()).Return(stubDescribeLoadBalancersOutput(), nil).AnyTimes()
 			mockAWSClient.EXPECT().ELBv2DescribeTargetGroups(gomock.Any()).Return(stubDescribeTargetGroupsOutput(), nil).AnyTimes()
 			mockAWSClient.EXPECT().ELBv2RegisterTargets(gomock.Any()).Return(nil, nil).AnyTimes()
+			mockAWSClient.EXPECT().ELBv2DescribeTargetHealth(gomock.Any()).Return(stubDescribeTargetHealthOutput(), nil).AnyTimes()
+			mockAWSClient.EXPECT().ELBv2DeregisterTargets(gomock.Any()).Return(nil, nil).AnyTimes()
 			mockAWSClient.EXPECT().DescribeVpcs(gomock.Any()).Return(StubDescribeVPCs()).AnyTimes()
 			mockAWSClient.EXPECT().DescribeDHCPOptions(gomock.Any()).Return(StubDescribeDHCPOptions()).AnyTimes()
 			mockAWSClient.EXPECT().CreateTags(gomock.Any()).Return(&ec2.CreateTagsOutput{}, nil).AnyTimes()

--- a/pkg/actuators/machine/instances_test.go
+++ b/pkg/actuators/machine/instances_test.go
@@ -495,7 +495,7 @@ func TestLaunchInstance(t *testing.T) {
 					},
 				},
 			},
-			instancesOutput: stubReservation(stubAMIID, stubInstanceID),
+			instancesOutput: stubReservation(stubAMIID, stubInstanceID, "192.168.0.10"),
 			succeeds:        true,
 			runInstancesInput: &ec2.RunInstancesInput{
 				IamInstanceProfile: &ec2.IamInstanceProfileSpecification{
@@ -585,7 +585,7 @@ func TestLaunchInstance(t *testing.T) {
 					},
 				},
 			},
-			instancesOutput: stubReservation(stubAMIID, stubInstanceID),
+			instancesOutput: stubReservation(stubAMIID, stubInstanceID, "192.168.0.10"),
 			succeeds:        true,
 			runInstancesInput: &ec2.RunInstancesInput{
 				IamInstanceProfile: &ec2.IamInstanceProfileSpecification{
@@ -655,7 +655,7 @@ func TestLaunchInstance(t *testing.T) {
 					},
 				},
 			},
-			instancesOutput: stubReservation(stubAMIID, stubInstanceID),
+			instancesOutput: stubReservation(stubAMIID, stubInstanceID, "192.168.0.10"),
 			succeeds:        true,
 			runInstancesInput: &ec2.RunInstancesInput{
 				IamInstanceProfile: &ec2.IamInstanceProfileSpecification{
@@ -768,7 +768,7 @@ func TestLaunchInstance(t *testing.T) {
 					},
 				},
 			},
-			instancesOutput: stubReservation(stubAMIID, stubInstanceID),
+			instancesOutput: stubReservation(stubAMIID, stubInstanceID, "192.168.0.10"),
 			succeeds:        true,
 			runInstancesInput: &ec2.RunInstancesInput{
 				IamInstanceProfile: &ec2.IamInstanceProfileSpecification{

--- a/pkg/actuators/machine/loadbalancers_test.go
+++ b/pkg/actuators/machine/loadbalancers_test.go
@@ -45,6 +45,7 @@ func TestRegisterWithNetworkLoadBalancers(t *testing.T) {
 			mockAWSClient.EXPECT().ELBv2DescribeLoadBalancers(gomock.Any()).Return(stubDescribeLoadBalancersOutput(), tc.lbErr)
 			mockAWSClient.EXPECT().ELBv2DescribeTargetGroups(gomock.Any()).Return(stubDescribeTargetGroupsOutput(), tc.targetGroupErr).AnyTimes()
 			mockAWSClient.EXPECT().ELBv2RegisterTargets(gomock.Any()).Return(nil, tc.registerTargetErr).AnyTimes()
+			mockAWSClient.EXPECT().ELBv2DescribeTargetHealth(gomock.Any()).Return(&elbv2.DescribeTargetHealthOutput{}, nil).AnyTimes()
 			registerWithNetworkLoadBalancers(mockAWSClient, []string{"name1", "name2"}, instance)
 		})
 	}

--- a/pkg/actuators/machine/reconciler_test.go
+++ b/pkg/actuators/machine/reconciler_test.go
@@ -198,12 +198,13 @@ func TestCreate(t *testing.T) {
 	mockAWSClient.EXPECT().DescribeSecurityGroups(gomock.Any()).Return(nil, fmt.Errorf("describeSecurityGroups error")).AnyTimes()
 	mockAWSClient.EXPECT().DescribeAvailabilityZones(gomock.Any()).Return(nil, fmt.Errorf("describeAvailabilityZones error")).AnyTimes()
 	mockAWSClient.EXPECT().DescribeImages(gomock.Any()).Return(nil, fmt.Errorf("describeImages error")).AnyTimes()
-	mockAWSClient.EXPECT().DescribeInstances(gomock.Any()).Return(stubDescribeInstancesOutput("ami-a9acbbd6", "i-02fcb933c5da7085c", ec2.InstanceStateNameRunning), nil).AnyTimes()
+	mockAWSClient.EXPECT().DescribeInstances(gomock.Any()).Return(stubDescribeInstancesOutput("ami-a9acbbd6", "i-02fcb933c5da7085c", ec2.InstanceStateNameRunning, "192.168.0.10"), nil).AnyTimes()
 	mockAWSClient.EXPECT().TerminateInstances(gomock.Any()).Return(&ec2.TerminateInstancesOutput{}, nil).AnyTimes()
-	mockAWSClient.EXPECT().RunInstances(gomock.Any()).Return(stubReservation("ami-a9acbbd6", "i-02fcb933c5da7085c"), nil).AnyTimes()
+	mockAWSClient.EXPECT().RunInstances(gomock.Any()).Return(stubReservation("ami-a9acbbd6", "i-02fcb933c5da7085c", "192.168.0.10"), nil).AnyTimes()
 	mockAWSClient.EXPECT().RegisterInstancesWithLoadBalancer(gomock.Any()).Return(nil, nil).AnyTimes()
 	mockAWSClient.EXPECT().ELBv2DescribeLoadBalancers(gomock.Any()).Return(stubDescribeLoadBalancersOutput(), nil)
 	mockAWSClient.EXPECT().ELBv2DescribeTargetGroups(gomock.Any()).Return(stubDescribeTargetGroupsOutput(), nil).AnyTimes()
+	mockAWSClient.EXPECT().ELBv2DescribeTargetHealth(gomock.Any()).Return(stubDescribeTargetHealthOutput(), nil).AnyTimes()
 	mockAWSClient.EXPECT().ELBv2RegisterTargets(gomock.Any()).Return(nil, nil).AnyTimes()
 	mockAWSClient.EXPECT().DescribeVpcs(gomock.Any()).Return(StubDescribeVPCs()).AnyTimes()
 	mockAWSClient.EXPECT().DescribeDHCPOptions(gomock.Any()).Return(StubDescribeDHCPOptions()).AnyTimes()
@@ -569,7 +570,7 @@ func TestGetMachineInstances(t *testing.T) {
 				}
 
 				mockAWSClient.EXPECT().DescribeInstances(request).Return(
-					stubDescribeInstancesOutput(imageID, instanceID, ec2.InstanceStateNameRunning),
+					stubDescribeInstancesOutput(imageID, instanceID, ec2.InstanceStateNameRunning, "192.168.0.10"),
 					nil,
 				).Times(1)
 
@@ -590,7 +591,7 @@ func TestGetMachineInstances(t *testing.T) {
 				}
 
 				mockAWSClient.EXPECT().DescribeInstances(request).Return(
-					stubDescribeInstancesOutput(imageID, instanceID, ec2.InstanceStateNameRunning),
+					stubDescribeInstancesOutput(imageID, instanceID, ec2.InstanceStateNameRunning, "192.168.0.10"),
 					nil,
 				).Times(1)
 
@@ -609,7 +610,7 @@ func TestGetMachineInstances(t *testing.T) {
 				first := mockAWSClient.EXPECT().DescribeInstances(&ec2.DescribeInstancesInput{
 					InstanceIds: aws.StringSlice([]string{instanceID}),
 				}).Return(
-					stubDescribeInstancesOutput(imageID, instanceID, ec2.InstanceStateNameTerminated),
+					stubDescribeInstancesOutput(imageID, instanceID, ec2.InstanceStateNameTerminated, "192.168.0.10"),
 					nil,
 				).Times(1)
 
@@ -623,7 +624,7 @@ func TestGetMachineInstances(t *testing.T) {
 						clusterFilter(clusterID),
 					},
 				}).Return(
-					stubDescribeInstancesOutput(imageID, instanceID, ec2.InstanceStateNameTerminated),
+					stubDescribeInstancesOutput(imageID, instanceID, ec2.InstanceStateNameTerminated, "192.168.0.10"),
 					nil,
 				).Times(1).After(first)
 

--- a/pkg/actuators/machine/stubs.go
+++ b/pkg/actuators/machine/stubs.go
@@ -258,7 +258,11 @@ func stubDescribeTargetGroupsOutput() *elbv2.DescribeTargetGroupsOutput {
 	}
 }
 
-func stubReservation(imageID, instanceID string) *ec2.Reservation {
+func stubDescribeTargetHealthOutput() *elbv2.DescribeTargetHealthOutput {
+	return &elbv2.DescribeTargetHealthOutput{}
+}
+
+func stubReservation(imageID, instanceID string, privateIP string) *ec2.Reservation {
 	az := defaultAvailabilityZone
 	return &ec2.Reservation{
 		Instances: []*ec2.Instance{
@@ -273,12 +277,13 @@ func stubReservation(imageID, instanceID string) *ec2.Reservation {
 				Placement: &ec2.Placement{
 					AvailabilityZone: &az,
 				},
+				PrivateIpAddress: aws.String(privateIP),
 			},
 		},
 	}
 }
 
-func stubDescribeInstancesOutput(imageID, instanceID string, state string) *ec2.DescribeInstancesOutput {
+func stubDescribeInstancesOutput(imageID, instanceID string, state string, privateIP string) *ec2.DescribeInstancesOutput {
 	return &ec2.DescribeInstancesOutput{
 		Reservations: []*ec2.Reservation{
 			{
@@ -290,7 +295,8 @@ func stubDescribeInstancesOutput(imageID, instanceID string, state string) *ec2.
 							Name: aws.String(state),
 							Code: aws.Int64(16),
 						},
-						LaunchTime: aws.Time(time.Now()),
+						LaunchTime:       aws.Time(time.Now()),
+						PrivateIpAddress: aws.String(privateIP),
 					},
 				},
 			},

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -84,6 +84,7 @@ type Client interface {
 	RegisterInstancesWithLoadBalancer(*elb.RegisterInstancesWithLoadBalancerInput) (*elb.RegisterInstancesWithLoadBalancerOutput, error)
 	ELBv2DescribeLoadBalancers(*elbv2.DescribeLoadBalancersInput) (*elbv2.DescribeLoadBalancersOutput, error)
 	ELBv2DescribeTargetGroups(*elbv2.DescribeTargetGroupsInput) (*elbv2.DescribeTargetGroupsOutput, error)
+	ELBv2DescribeTargetHealth(*elbv2.DescribeTargetHealthInput) (*elbv2.DescribeTargetHealthOutput, error)
 	ELBv2RegisterTargets(*elbv2.RegisterTargetsInput) (*elbv2.RegisterTargetsOutput, error)
 	ELBv2DeregisterTargets(*elbv2.DeregisterTargetsInput) (*elbv2.DeregisterTargetsOutput, error)
 }
@@ -148,6 +149,10 @@ func (c *awsClient) ELBv2DescribeLoadBalancers(input *elbv2.DescribeLoadBalancer
 
 func (c *awsClient) ELBv2DescribeTargetGroups(input *elbv2.DescribeTargetGroupsInput) (*elbv2.DescribeTargetGroupsOutput, error) {
 	return c.elbv2Client.DescribeTargetGroups(input)
+}
+
+func (c *awsClient) ELBv2DescribeTargetHealth(input *elbv2.DescribeTargetHealthInput) (*elbv2.DescribeTargetHealthOutput, error) {
+	return c.elbv2Client.DescribeTargetHealth(input)
 }
 
 func (c *awsClient) ELBv2RegisterTargets(input *elbv2.RegisterTargetsInput) (*elbv2.RegisterTargetsOutput, error) {

--- a/pkg/client/fake/fake.go
+++ b/pkg/client/fake/fake.go
@@ -120,6 +120,10 @@ func (c *awsClient) ELBv2DescribeTargetGroups(*elbv2.DescribeTargetGroupsInput) 
 	return &elbv2.DescribeTargetGroupsOutput{}, nil
 }
 
+func (c *awsClient) ELBv2DescribeTargetHealth(*elbv2.DescribeTargetHealthInput) (*elbv2.DescribeTargetHealthOutput, error) {
+	return &elbv2.DescribeTargetHealthOutput{}, nil
+}
+
 func (c *awsClient) ELBv2RegisterTargets(*elbv2.RegisterTargetsInput) (*elbv2.RegisterTargetsOutput, error) {
 	// Feel free to extend the returned values
 	return &elbv2.RegisterTargetsOutput{}, nil

--- a/pkg/client/mock/client_generated.go
+++ b/pkg/client/mock/client_generated.go
@@ -246,6 +246,21 @@ func (mr *MockClientMockRecorder) ELBv2DescribeTargetGroups(arg0 interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ELBv2DescribeTargetGroups", reflect.TypeOf((*MockClient)(nil).ELBv2DescribeTargetGroups), arg0)
 }
 
+// ELBv2DescribeTargetHealth mocks base method
+func (m *MockClient) ELBv2DescribeTargetHealth(arg0 *elbv2.DescribeTargetHealthInput) (*elbv2.DescribeTargetHealthOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ELBv2DescribeTargetHealth", arg0)
+	ret0, _ := ret[0].(*elbv2.DescribeTargetHealthOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ELBv2DescribeTargetHealth indicates an expected call of ELBv2DescribeTargetHealth
+func (mr *MockClientMockRecorder) ELBv2DescribeTargetHealth(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ELBv2DescribeTargetHealth", reflect.TypeOf((*MockClient)(nil).ELBv2DescribeTargetHealth), arg0)
+}
+
 // ELBv2RegisterTargets mocks base method
 func (m *MockClient) ELBv2RegisterTargets(arg0 *elbv2.RegisterTargetsInput) (*elbv2.RegisterTargetsOutput, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
This PR changes the load balancer registration logic so that we only actually register targets if and when they need registering, rather than constantly registering them whenever the machine is reconciled.

When using write operations, this tends to be more expensive for an API, if we can prevent write operations by using a read first, we are in the most case, being a better consumer of the API.

In the case of this bug, we are seeing frequent requests to an API which doesn't have the correct permissions, because this is an inferred permission, this should reduce this kind of problem in the future.