### PR TITLE
[release-4.8] Bug 1974680: Fix eventual consistency logic to be consistent

### DIFF
--- a/pkg/actuators/machine/actuator_test.go
+++ b/pkg/actuators/machine/actuator_test.go
@@ -176,7 +176,7 @@ func TestMachineEvents(t *testing.T) {
 			if tc.awsError {
 				mockAWSClient.EXPECT().DescribeInstances(gomock.Any()).Return(nil, errors.New("AWS error")).AnyTimes()
 			} else {
-				mockAWSClient.EXPECT().DescribeInstances(gomock.Any()).Return(stubDescribeInstancesOutput("ami-a9acbbd6", "i-02fcb933c5da7085c", ec2.InstanceStateNameRunning), nil).AnyTimes()
+				mockAWSClient.EXPECT().DescribeInstances(gomock.Any()).Return(stubDescribeInstancesOutput("ami-a9acbbd6", "i-02fcb933c5da7085c", ec2.InstanceStateNameRunning, "192.168.0.10"), nil).AnyTimes()
 			}
 
 			mockAWSClient.EXPECT().RunInstances(gomock.Any()).Return(stubReservation("ami-a9acbbd6", "i-02fcb933c5da7085c"), nil).AnyTimes()
@@ -187,6 +187,7 @@ func TestMachineEvents(t *testing.T) {
 			mockAWSClient.EXPECT().ELBv2DescribeLoadBalancers(gomock.Any()).Return(stubDescribeLoadBalancersOutput(), nil).AnyTimes()
 			mockAWSClient.EXPECT().ELBv2DescribeTargetGroups(gomock.Any()).Return(stubDescribeTargetGroupsOutput(), nil).AnyTimes()
 			mockAWSClient.EXPECT().ELBv2RegisterTargets(gomock.Any()).Return(nil, nil).AnyTimes()
+			mockAWSClient.EXPECT().ELBv2DeregisterTargets(gomock.Any()).Return(nil, nil).AnyTimes()
 			mockAWSClient.EXPECT().DescribeVpcs(gomock.Any()).Return(StubDescribeVPCs()).AnyTimes()
 			mockAWSClient.EXPECT().DescribeDHCPOptions(gomock.Any()).Return(StubDescribeDHCPOptions()).AnyTimes()
 			mockAWSClient.EXPECT().CreateTags(gomock.Any()).Return(&ec2.CreateTagsOutput{}, nil).AnyTimes()

--- a/pkg/actuators/machine/reconciler.go
+++ b/pkg/actuators/machine/reconciler.go
@@ -103,7 +103,7 @@ func (r *Reconciler) create() error {
 
 	r.machineScope.setProviderStatus(instance, conditionSuccess())
 
-	return r.requeueIfInstancePending(instance)
+	return nil
 }
 
 // delete deletes machine
@@ -181,7 +181,7 @@ func (r *Reconciler) update() error {
 
 	existingLen := len(existingInstances)
 	if existingLen == 0 {
-		if r.machine.Spec.ProviderID != nil && *r.machine.Spec.ProviderID != "" && (r.machine.Status.LastUpdated == nil || r.machine.Status.LastUpdated.Add(requeueAfterSeconds*time.Second).After(time.Now())) {
+		if r.machine.Spec.ProviderID != nil && *r.machine.Spec.ProviderID != "" && len(r.machine.Status.Addresses) == 0 {
 			klog.Infof("%s: Possible eventual-consistency discrepancy; returning an error to requeue", r.machine.Name)
 			return &machinecontroller.RequeueAfterError{RequeueAfter: requeueAfterSeconds * time.Second}
 		}
@@ -257,7 +257,7 @@ func (r *Reconciler) exists() (bool, error) {
 	}
 
 	if len(existingInstances) == 0 {
-		if r.machine.Spec.ProviderID != nil && *r.machine.Spec.ProviderID != "" && (r.machine.Status.LastUpdated == nil || r.machine.Status.LastUpdated.Add(requeueAfterSeconds*time.Second).After(time.Now())) {
+		if r.machine.Spec.ProviderID != nil && *r.machine.Spec.ProviderID != "" && len(r.machine.Status.Addresses) == 0 {
 			klog.Infof("%s: Possible eventual-consistency discrepancy; returning an error to requeue", r.machine.Name)
 			return false, &machinecontroller.RequeueAfterError{RequeueAfter: requeueAfterSeconds * time.Second}
 		}

--- a/pkg/actuators/machine/reconciler_test.go
+++ b/pkg/actuators/machine/reconciler_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/golang/mock/gomock"
 	configv1 "github.com/openshift/api/config/v1"
 	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	machinecontroller "github.com/openshift/machine-api-operator/pkg/controller/machine"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -198,7 +199,7 @@ func TestCreate(t *testing.T) {
 	mockAWSClient.EXPECT().DescribeSecurityGroups(gomock.Any()).Return(nil, fmt.Errorf("describeSecurityGroups error")).AnyTimes()
 	mockAWSClient.EXPECT().DescribeAvailabilityZones(gomock.Any()).Return(nil, fmt.Errorf("describeAvailabilityZones error")).AnyTimes()
 	mockAWSClient.EXPECT().DescribeImages(gomock.Any()).Return(nil, fmt.Errorf("describeImages error")).AnyTimes()
-	mockAWSClient.EXPECT().DescribeInstances(gomock.Any()).Return(stubDescribeInstancesOutput("ami-a9acbbd6", "i-02fcb933c5da7085c", ec2.InstanceStateNameRunning), nil).AnyTimes()
+	mockAWSClient.EXPECT().DescribeInstances(gomock.Any()).Return(stubDescribeInstancesOutput("ami-a9acbbd6", "i-02fcb933c5da7085c", ec2.InstanceStateNameRunning, "192.168.0.10"), nil).AnyTimes()
 	mockAWSClient.EXPECT().TerminateInstances(gomock.Any()).Return(&ec2.TerminateInstancesOutput{}, nil).AnyTimes()
 	mockAWSClient.EXPECT().RunInstances(gomock.Any()).Return(stubReservation("ami-a9acbbd6", "i-02fcb933c5da7085c"), nil).AnyTimes()
 	mockAWSClient.EXPECT().RegisterInstancesWithLoadBalancer(gomock.Any()).Return(nil, nil).AnyTimes()
@@ -495,12 +496,7 @@ func TestCreate(t *testing.T) {
 		}
 		machine.Spec.ProviderSpec = machinev1.ProviderSpec{Value: encodedProviderConfig}
 
-		fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme, machine, tc.awsCredentialsSecret, tc.userDataSecret)
-
-		err = fakeClient.Create(context.Background(), &configv1.Infrastructure{ObjectMeta: metav1.ObjectMeta{Name: awsclient.GlobalInfrastuctureName}})
-		if err != nil {
-			t.Fatal(err)
-		}
+		fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme, machine, tc.awsCredentialsSecret, tc.userDataSecret, stubInfraObject())
 
 		machineScope, err := newMachineScope(machineScopeParams{
 			client:  fakeClient,
@@ -517,6 +513,11 @@ func TestCreate(t *testing.T) {
 
 		// test create
 		err = reconciler.create()
+
+		if errors.Is(err, &machinecontroller.RequeueAfterError{}) {
+			t.Error("RequeueAfterError should not be returned by reconciler.create()")
+		}
+
 		if tc.expectedError != nil {
 			if err == nil {
 				t.Error("reconciler was expected to return error")
@@ -529,6 +530,225 @@ func TestCreate(t *testing.T) {
 				t.Errorf("reconciler was not expected to return error: %v", err)
 			}
 		}
+	}
+}
+
+func TestExists(t *testing.T) {
+	testCases := []struct {
+		name          string
+		machine       func() *machinev1.Machine
+		expectedError error
+		existsResult  bool
+		awsClient     func(ctrl *gomock.Controller) awsclient.Client
+	}{
+		{
+			name: "Successfully find created instance",
+			machine: func() *machinev1.Machine {
+				machine, err := stubMachine()
+				if err != nil {
+					t.Fatalf("unable to build stub machine: %v", err)
+				}
+
+				return machine
+			},
+			existsResult:  true,
+			expectedError: nil,
+			awsClient: func(ctrl *gomock.Controller) awsclient.Client {
+				mockCtrl := gomock.NewController(t)
+				mockAWSClient := mockaws.NewMockClient(mockCtrl)
+				mockAWSClient.EXPECT().DescribeInstances(gomock.Any()).Return(stubDescribeInstancesOutput("test-ami", "test-id", ec2.InstanceStateNameRunning, "1.1.1.1"), nil).AnyTimes()
+				return mockAWSClient
+			},
+		},
+		{
+			name: "Requeue if machine has providerID and addresses are not set",
+			machine: func() *machinev1.Machine {
+				machine, err := stubMachine()
+				if err != nil {
+					t.Fatalf("unable to build stub machine: %v", err)
+				}
+
+				machine.Spec.ProviderID = func() *string {
+					providerID := "test"
+					return &providerID
+				}()
+
+				return machine
+			},
+			existsResult:  false,
+			expectedError: &machinecontroller.RequeueAfterError{RequeueAfter: requeueAfterSeconds * time.Second},
+			awsClient: func(ctrl *gomock.Controller) awsclient.Client {
+				mockCtrl := gomock.NewController(t)
+				mockAWSClient := mockaws.NewMockClient(mockCtrl)
+				mockAWSClient.EXPECT().DescribeInstances(gomock.Any()).Return(&ec2.DescribeInstancesOutput{}, nil).AnyTimes()
+				return mockAWSClient
+			},
+		},
+		{
+			name: "Fail to find instance",
+			machine: func() *machinev1.Machine {
+				machine, err := stubMachine()
+				if err != nil {
+					t.Fatalf("unable to build stub machine: %v", err)
+				}
+
+				return machine
+			},
+			existsResult:  false,
+			expectedError: nil,
+			awsClient: func(ctrl *gomock.Controller) awsclient.Client {
+				mockCtrl := gomock.NewController(t)
+				mockAWSClient := mockaws.NewMockClient(mockCtrl)
+				mockAWSClient.EXPECT().DescribeInstances(gomock.Any()).Return(&ec2.DescribeInstancesOutput{}, nil).AnyTimes()
+				return mockAWSClient
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme, tc.machine(), stubAwsCredentialsSecret(), stubUserDataSecret(), stubInfraObject())
+
+			machineScope, err := newMachineScope(machineScopeParams{
+				client:  fakeClient,
+				machine: tc.machine(),
+				awsClientBuilder: func(client runtimeclient.Client, secretName, namespace, region string, configManagedClient runtimeclient.Client) (awsclient.Client, error) {
+					return tc.awsClient(ctrl), nil
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			reconciler := newReconciler(machineScope)
+
+			exists, err := reconciler.exists()
+
+			if tc.existsResult != exists {
+				t.Errorf("expected reconciler tc.Exists() to return: %v, got %v", tc.existsResult, exists)
+			}
+
+			if tc.expectedError != nil {
+				if err == nil {
+					t.Error("reconciler was expected to return error")
+				}
+
+				if err.Error() != tc.expectedError.Error() {
+					t.Errorf("expected: %v, got %v", tc.expectedError, err)
+				}
+
+			} else {
+				if err != nil {
+					t.Errorf("reconciler was not expected to return error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	// TODO: check machine object after calling update()
+	testCases := []struct {
+		name          string
+		machine       func() *machinev1.Machine
+		expectedError error
+		awsClient     func(ctrl *gomock.Controller) awsclient.Client
+	}{
+		{
+			name: "Successfully update the machine",
+			machine: func() *machinev1.Machine {
+				machine, err := stubMachine()
+				if err != nil {
+					t.Fatalf("unable to build stub machine: %v", err)
+				}
+
+				return machine
+			},
+
+			expectedError: nil,
+			awsClient: func(ctrl *gomock.Controller) awsclient.Client {
+				mockCtrl := gomock.NewController(t)
+				mockAWSClient := mockaws.NewMockClient(mockCtrl)
+				mockAWSClient.EXPECT().DescribeInstances(gomock.Any()).Return(stubDescribeInstancesOutput("test-ami", "test-id", ec2.InstanceStateNameRunning, "1.1.1.1"), nil).AnyTimes()
+				mockAWSClient.EXPECT().RegisterInstancesWithLoadBalancer(gomock.Any()).AnyTimes()
+				mockAWSClient.EXPECT().ELBv2DescribeLoadBalancers(gomock.Any()).Return(stubDescribeLoadBalancersOutput(), nil)
+				mockAWSClient.EXPECT().ELBv2DescribeTargetGroups(gomock.Any()).Return(stubDescribeTargetGroupsOutput(), nil).AnyTimes()
+				mockAWSClient.EXPECT().ELBv2RegisterTargets(gomock.Any()).Return(nil, nil).AnyTimes()
+				mockAWSClient.EXPECT().CreateTags(gomock.Any()).Return(&ec2.CreateTagsOutput{}, nil).AnyTimes()
+				mockAWSClient.EXPECT().DescribeVpcs(gomock.Any()).Return(StubDescribeVPCs()).AnyTimes()
+				return mockAWSClient
+			},
+		},
+		{
+			name: "Requeue if machine has providerID and addresses are not set",
+			machine: func() *machinev1.Machine {
+				machine, err := stubMachine()
+				if err != nil {
+					t.Fatalf("unable to build stub machine: %v", err)
+				}
+
+				machine.Spec.ProviderID = func() *string {
+					providerID := "test"
+					return &providerID
+				}()
+
+				return machine
+			},
+
+			expectedError: &machinecontroller.RequeueAfterError{RequeueAfter: requeueAfterSeconds * time.Second},
+			awsClient: func(ctrl *gomock.Controller) awsclient.Client {
+				mockCtrl := gomock.NewController(t)
+				mockAWSClient := mockaws.NewMockClient(mockCtrl)
+				mockAWSClient.EXPECT().DescribeInstances(gomock.Any()).Return(&ec2.DescribeInstancesOutput{}, nil).AnyTimes()
+				mockAWSClient.EXPECT().RegisterInstancesWithLoadBalancer(gomock.Any()).AnyTimes()
+				mockAWSClient.EXPECT().ELBv2DescribeLoadBalancers(gomock.Any()).Return(stubDescribeLoadBalancersOutput(), nil)
+				mockAWSClient.EXPECT().ELBv2DescribeTargetGroups(gomock.Any()).Return(stubDescribeTargetGroupsOutput(), nil).AnyTimes()
+				mockAWSClient.EXPECT().ELBv2RegisterTargets(gomock.Any()).Return(nil, nil).AnyTimes()
+				mockAWSClient.EXPECT().CreateTags(gomock.Any()).Return(&ec2.CreateTagsOutput{}, nil).AnyTimes()
+				mockAWSClient.EXPECT().DescribeVpcs(gomock.Any()).Return(StubDescribeVPCs()).AnyTimes()
+				return mockAWSClient
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme, tc.machine(), stubAwsCredentialsSecret(), stubUserDataSecret(), stubInfraObject())
+
+			machineScope, err := newMachineScope(machineScopeParams{
+				client:  fakeClient,
+				machine: tc.machine(),
+				awsClientBuilder: func(client runtimeclient.Client, secretName, namespace, region string, configManagedClient runtimeclient.Client) (awsclient.Client, error) {
+					return tc.awsClient(ctrl), nil
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			reconciler := newReconciler(machineScope)
+
+			err = reconciler.update()
+
+			if tc.expectedError != nil {
+				if err == nil {
+					t.Error("reconciler was expected to return error")
+				}
+
+				if err.Error() != tc.expectedError.Error() {
+					t.Errorf("expected: %v, got %v", tc.expectedError, err)
+				}
+
+			} else {
+				if err != nil {
+					t.Errorf("reconciler was not expected to return error: %v", err)
+				}
+			}
+		})
 	}
 }
 
@@ -569,7 +789,7 @@ func TestGetMachineInstances(t *testing.T) {
 				}
 
 				mockAWSClient.EXPECT().DescribeInstances(request).Return(
-					stubDescribeInstancesOutput(imageID, instanceID, ec2.InstanceStateNameRunning),
+					stubDescribeInstancesOutput(imageID, instanceID, ec2.InstanceStateNameRunning, "192.168.0.10"),
 					nil,
 				).Times(1)
 
@@ -590,7 +810,7 @@ func TestGetMachineInstances(t *testing.T) {
 				}
 
 				mockAWSClient.EXPECT().DescribeInstances(request).Return(
-					stubDescribeInstancesOutput(imageID, instanceID, ec2.InstanceStateNameRunning),
+					stubDescribeInstancesOutput(imageID, instanceID, ec2.InstanceStateNameRunning, "192.168.0.10"),
 					nil,
 				).Times(1)
 
@@ -609,7 +829,7 @@ func TestGetMachineInstances(t *testing.T) {
 				first := mockAWSClient.EXPECT().DescribeInstances(&ec2.DescribeInstancesInput{
 					InstanceIds: aws.StringSlice([]string{instanceID}),
 				}).Return(
-					stubDescribeInstancesOutput(imageID, instanceID, ec2.InstanceStateNameTerminated),
+					stubDescribeInstancesOutput(imageID, instanceID, ec2.InstanceStateNameTerminated, "192.168.0.10"),
 					nil,
 				).Times(1)
 
@@ -623,7 +843,7 @@ func TestGetMachineInstances(t *testing.T) {
 						clusterFilter(clusterID),
 					},
 				}).Return(
-					stubDescribeInstancesOutput(imageID, instanceID, ec2.InstanceStateNameTerminated),
+					stubDescribeInstancesOutput(imageID, instanceID, ec2.InstanceStateNameTerminated, "192.168.0.10"),
 					nil,
 				).Times(1).After(first)
 

--- a/pkg/actuators/machine/stubs.go
+++ b/pkg/actuators/machine/stubs.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elbv2"
+	configv1 "github.com/openshift/api/config/v1"
 	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	machinecontroller "github.com/openshift/machine-api-operator/pkg/controller/machine"
 	corev1 "k8s.io/api/core/v1"
@@ -266,7 +267,7 @@ func stubReservation(imageID, instanceID string) *ec2.Reservation {
 				ImageId:    aws.String(imageID),
 				InstanceId: aws.String(instanceID),
 				State: &ec2.InstanceState{
-					Name: aws.String(ec2.InstanceStateNameRunning),
+					Name: aws.String(ec2.InstanceStateNamePending),
 					Code: aws.Int64(16),
 				},
 				LaunchTime: aws.Time(time.Now()),
@@ -278,7 +279,7 @@ func stubReservation(imageID, instanceID string) *ec2.Reservation {
 	}
 }
 
-func stubDescribeInstancesOutput(imageID, instanceID string, state string) *ec2.DescribeInstancesOutput {
+func stubDescribeInstancesOutput(imageID, instanceID string, state string, privateIP string) *ec2.DescribeInstancesOutput {
 	return &ec2.DescribeInstancesOutput{
 		Reservations: []*ec2.Reservation{
 			{
@@ -290,7 +291,8 @@ func stubDescribeInstancesOutput(imageID, instanceID string, state string) *ec2.
 							Name: aws.String(state),
 							Code: aws.Int64(16),
 						},
-						LaunchTime: aws.Time(time.Now()),
+						LaunchTime:       aws.Time(time.Now()),
+						PrivateIpAddress: aws.String(privateIP),
 					},
 				},
 			},
@@ -324,4 +326,12 @@ func StubDescribeVPCs() (*ec2.DescribeVpcsOutput, error) {
 			},
 		},
 	}, nil
+}
+
+func stubInfraObject() *configv1.Infrastructure {
+	return &configv1.Infrastructure{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: awsclient.GlobalInfrastuctureName,
+		},
+	}
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/openshift/cluster-api-provider-aws/pull/406