### PR TITLE
Bug 2029993: Prevent Machine from being considered provisioned until it exists in AWS

### DIFF
--- a/pkg/actuators/machine/actuator_test.go
+++ b/pkg/actuators/machine/actuator_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
+	awsproviderv1 "sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsprovider/v1beta1"
 	awsclient "sigs.k8s.io/cluster-api-provider-aws/pkg/client"
 	mockaws "sigs.k8s.io/cluster-api-provider-aws/pkg/client/mock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -29,6 +30,7 @@ func init() {
 }
 
 func TestMachineEvents(t *testing.T) {
+	instanceID := "i-02fcb933c5da7085c"
 	g := NewWithT(t)
 
 	awsCredentialsSecret := stubAwsCredentialsSecret()
@@ -50,6 +52,7 @@ func TestMachineEvents(t *testing.T) {
 		event               string
 		awsError            bool
 		invalidMachineScope bool
+		setInstanceID       bool
 	}{
 		{
 			name: "Create machine event failed on invalid machine scope",
@@ -102,7 +105,8 @@ func TestMachineEvents(t *testing.T) {
 				actuator.Update(context.TODO(), machine)
 				actuator.Update(context.TODO(), machine)
 			},
-			event: "Updated Machine aws-actuator-testing-machine",
+			setInstanceID: true, // This implies the machine was already created
+			event:         "Updated Machine aws-actuator-testing-machine",
 		},
 		{
 			name: "Delete machine event failed on invalid machine scope",
@@ -127,6 +131,7 @@ func TestMachineEvents(t *testing.T) {
 			operation: func(actuator *Actuator, machine *machinev1.Machine) {
 				actuator.Delete(context.TODO(), machine)
 			},
+			setInstanceID:       true, // This implies the machine was already created
 			event:               "Deleted machine aws-actuator-testing-machine",
 			invalidMachineScope: false,
 			awsError:            false,
@@ -173,13 +178,37 @@ func TestMachineEvents(t *testing.T) {
 				}
 			}
 
+			if tc.setInstanceID {
+				updateInstanceID := func() error {
+					if getMachine(); err != nil {
+						return err
+					}
+
+					ps, err := awsproviderv1.ProviderStatusFromRawExtension(machine.Status.ProviderStatus)
+					if err != nil {
+						return err
+					}
+					ps.InstanceID = &instanceID
+
+					raw, err := awsproviderv1.RawExtensionFromProviderStatus(ps)
+					if err != nil {
+						return err
+					}
+					machine.Status.ProviderStatus = raw
+
+					return k8sClient.Status().Update(ctx, machine)
+				}
+				gs.Eventually(updateInstanceID, timeout).Should(Succeed())
+			}
+
 			if tc.awsError {
 				mockAWSClient.EXPECT().DescribeInstances(gomock.Any()).Return(nil, errors.New("AWS error")).AnyTimes()
 			} else {
-				mockAWSClient.EXPECT().DescribeInstances(gomock.Any()).Return(stubDescribeInstancesOutput("ami-a9acbbd6", "i-02fcb933c5da7085c", ec2.InstanceStateNameRunning, "192.168.0.10"), nil).AnyTimes()
+				mockAWSClient.EXPECT().DescribeInstances(stubDescribeInstancesInput(instanceID)).Return(stubDescribeInstancesOutput("ami-a9acbbd6", instanceID, ec2.InstanceStateNameRunning, "192.168.0.10"), nil).AnyTimes()
+				mockAWSClient.EXPECT().DescribeInstances(gomock.Any()).Return(&ec2.DescribeInstancesOutput{}, nil).AnyTimes()
 			}
 
-			mockAWSClient.EXPECT().RunInstances(gomock.Any()).Return(stubReservation("ami-a9acbbd6", "i-02fcb933c5da7085c", "192.168.0.10"), nil).AnyTimes()
+			mockAWSClient.EXPECT().RunInstances(gomock.Any()).Return(stubReservation("ami-a9acbbd6", instanceID, "192.168.0.10"), nil).AnyTimes()
 			mockAWSClient.EXPECT().TerminateInstances(gomock.Any()).Return(&ec2.TerminateInstancesOutput{}, nil).AnyTimes()
 			mockAWSClient.EXPECT().RegisterInstancesWithLoadBalancer(gomock.Any()).Return(nil, nil).AnyTimes()
 			mockAWSClient.EXPECT().TerminateInstances(gomock.Any()).Return(&ec2.TerminateInstancesOutput{}, nil).AnyTimes()

--- a/pkg/actuators/machine/controller_test.go
+++ b/pkg/actuators/machine/controller_test.go
@@ -1,0 +1,183 @@
+package machine
+
+import (
+	"context"
+	"errors"
+	"log"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
+	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	machinecontroller "github.com/openshift/machine-api-operator/pkg/controller/machine"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	awsproviderv1 "sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsprovider/v1beta1"
+	awsclient "sigs.k8s.io/cluster-api-provider-aws/pkg/client"
+	mockaws "sigs.k8s.io/cluster-api-provider-aws/pkg/client/mock"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+func TestMachineControllerWithDelayedExistSuccess(t *testing.T) {
+	ctx := context.TODO()
+	g := NewWithT(t)
+
+	mockCtrl := gomock.NewController(t)
+	mockAWSClient := mockaws.NewMockClient(mockCtrl)
+	awsClientBuilder := func(client runtimeclient.Client, secretName, namespace, region string, configManagedClient runtimeclient.Client) (awsclient.Client, error) {
+		return mockAWSClient, nil
+	}
+
+	{ // Initialise Mock AWS responses for client
+		log.Printf("Initialising mock AWS responses")
+
+		// DesrcibeInstances by tags should only happen before the instance is created/if the provider ID returns nothing
+		// For the purpose of this test, don't provide an output, we want to control the provider ID response instead.
+		mockAWSClient.EXPECT().DescribeInstances(stubDescribeInstancesInputFromName()).Return(&ec2.DescribeInstancesOutput{}, nil).AnyTimes()
+
+		// Once the actuator has determined the Machine doesn't exist, it should eventually request to create the machine
+		mockAWSClient.EXPECT().RunInstances(gomock.Any()).Return(stubReservation("ami-a9acbbd6", stubInstanceID, "192.168.0.10"), nil).Times(1)
+
+		// After the create, it will reconcile load balancer attachements, we don't care about these for this test
+		mockAWSClient.EXPECT().RegisterInstancesWithLoadBalancer(gomock.Any()).Return(nil, nil).AnyTimes()
+		mockAWSClient.EXPECT().ELBv2DescribeLoadBalancers(gomock.Any()).Return(stubDescribeLoadBalancersOutput(), nil).AnyTimes()
+		mockAWSClient.EXPECT().ELBv2DescribeTargetGroups(gomock.Any()).Return(stubDescribeTargetGroupsOutput(), nil).AnyTimes()
+		mockAWSClient.EXPECT().ELBv2RegisterTargets(gomock.Any()).Return(nil, nil).AnyTimes()
+		mockAWSClient.EXPECT().ELBv2DescribeTargetHealth(gomock.Any()).Return(stubDescribeTargetHealthOutput(), nil).AnyTimes()
+		mockAWSClient.EXPECT().DescribeVpcs(gomock.Any()).Return(StubDescribeVPCs()).AnyTimes()
+		mockAWSClient.EXPECT().DescribeDHCPOptions(gomock.Any()).Return(StubDescribeDHCPOptions()).AnyTimes()
+
+		// After create, we will assert that the instance doesn't exist for the first 3 times that the call is made
+		// - The first call is Exists, which will return that the instance does not exist
+		// - The second is in Create, check for possible eventual consistency errors. This will fail and then the
+		//   check for the providerStatus.InstanceID should prevent a second create and requeue.
+		// - The third call is Exists on the second reconcile, after which we start returning the instance to allow
+		//   the Create eventual consistency error to requeue again, after which Exists will succeed going forward.
+		assertNotExist := mockAWSClient.EXPECT().DescribeInstances(stubDescribeInstancesInput(stubInstanceID)).Return(&ec2.DescribeInstancesOutput{}, nil).MaxTimes(3)
+		mockAWSClient.EXPECT().DescribeInstances(stubDescribeInstancesInput(stubInstanceID)).Return(stubDescribeInstancesOutput("ami-a9acbbd6", stubInstanceID, ec2.InstanceStateNameRunning, "192.168.0.10"), nil).After(assertNotExist).AnyTimes()
+
+		// Once the machine gets to the update stage, tags will be updated
+		mockAWSClient.EXPECT().CreateTags(gomock.Any()).Return(&ec2.CreateTagsOutput{}, nil).AnyTimes()
+	}
+
+	var k8sClient runtimeclient.Client
+	{ // Set up manager, actuator and controller
+		log.Printf("Initialising manager, actuator and controller")
+		mgr, err := manager.New(cfg, manager.Options{
+			Scheme:             scheme.Scheme,
+			MetricsBindAddress: "0",
+		})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		mgrCtx, cancel := context.WithCancel(context.Background())
+		go func() {
+			g.Expect(mgr.Start(mgrCtx)).To(Succeed())
+		}()
+		defer cancel()
+
+		k8sClient = mgr.GetClient()
+		eventRecorder := mgr.GetEventRecorderFor("awscontroller")
+
+		params := ActuatorParams{
+			Client:           k8sClient,
+			EventRecorder:    eventRecorder,
+			AwsClientBuilder: awsClientBuilder,
+		}
+		actuator := NewActuator(params)
+
+		g.Expect(machinecontroller.AddWithActuator(mgr, actuator)).To(Succeed())
+	}
+
+	var machine *machinev1.Machine
+	var machineKey runtimeclient.ObjectKey
+	{ // Init and create the machine and infrastructure object
+		log.Printf("Initialising and creating the Machine and supporting resources")
+		var err error
+		machine, err = stubMachine()
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(stubMachine).ToNot(BeNil())
+		machineKey = runtimeclient.ObjectKey{Namespace: machine.Namespace, Name: machine.Name}
+
+		// Create the machine
+		g.Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+		defer func() {
+			g.Expect(k8sClient.Delete(ctx, machine)).To(Succeed())
+		}()
+
+		// Create infrastructure object
+		infra := &configv1.Infrastructure{ObjectMeta: metav1.ObjectMeta{Name: awsclient.GlobalInfrastuctureName}}
+		g.Expect(k8sClient.Create(ctx, infra)).To(Succeed())
+		defer func() {
+			g.Expect(k8sClient.Delete(ctx, infra)).To(Succeed())
+		}()
+
+		// Create the credentials secret
+		awsCredentialsSecret := stubAwsCredentialsSecret()
+		g.Expect(k8sClient.Create(context.TODO(), awsCredentialsSecret)).To(Succeed())
+		defer func() {
+			g.Expect(k8sClient.Delete(context.TODO(), awsCredentialsSecret)).To(Succeed())
+		}()
+
+		// Create the user data secret
+		userDataSecret := stubUserDataSecret()
+		g.Expect(k8sClient.Create(context.TODO(), userDataSecret)).To(Succeed())
+		defer func() {
+			g.Expect(k8sClient.Delete(context.TODO(), userDataSecret)).To(Succeed())
+		}()
+
+		// Ensure the machine has synced to the cache
+		getMachine := func() error {
+			return k8sClient.Get(ctx, machineKey, machine)
+		}
+		g.Eventually(getMachine, timeout).Should(Succeed())
+	}
+
+	{
+		log.Printf("Check expectations of Machine after create")
+		// First thing the Machine controller does is move the machine to provisioning and requeue
+		waitForProvisioning := func() (bool, error) {
+			if err := k8sClient.Get(ctx, machineKey, machine); err != nil {
+				return false, err
+			}
+			return machine.Status.Phase != nil && *machine.Status.Phase == "Provisioning", nil
+		}
+		g.Eventually(waitForProvisioning, timeout).Should(BeTrue(), "Machine was never moved to provisioning")
+
+		// Then we expect the controller to create the instance and set the instance ID
+		waitForInstanceID := func() (bool, error) {
+			if err := k8sClient.Get(ctx, machineKey, machine); err != nil {
+				return false, err
+			}
+			if machine.Status.ProviderStatus == nil {
+				return false, errors.New("expected providerstatus to not be nil")
+			}
+			ps, err := awsproviderv1.ProviderStatusFromRawExtension(machine.Status.ProviderStatus)
+			if err != nil {
+				return false, err
+			}
+			return ps.InstanceID != nil && *ps.InstanceID == stubInstanceID, nil
+		}
+		g.Eventually(waitForInstanceID, timeout).Should(BeTrue(), "Instance ID was not set in provider status")
+		g.Expect(machine.Spec.ProviderID).To(BeNil(), "Provider ID should not be set after create")
+		g.Expect(machine.Status.Addresses).To(BeEmpty(), "Expected addresses to not be set after create")
+	}
+
+	{
+		log.Printf("Check expectations of Machine after update")
+		// First thing the Machine controller does is move the machine to provisioning and requeue
+		waitForProvisioned := func() (bool, error) {
+			if err := k8sClient.Get(ctx, machineKey, machine); err != nil {
+				return false, err
+			}
+			return machine.Status.Phase != nil && *machine.Status.Phase == "Provisioned", nil
+		}
+		g.Eventually(waitForProvisioned, timeout).Should(BeTrue(), "Machine was never moved to provisioned")
+
+		g.Expect(machine.Spec.ProviderID).ToNot(BeNil())
+		g.Expect(*machine.Spec.ProviderID).To(ContainSubstring(stubInstanceID), "ProviderID should be set after update")
+		g.Expect(machine.Status.Addresses).To(HaveLen(4), "Expected addresses to be set after update")
+	}
+}

--- a/pkg/actuators/machine/reconciler.go
+++ b/pkg/actuators/machine/reconciler.go
@@ -40,6 +40,20 @@ func newReconciler(scope *machineScope) *Reconciler {
 func (r *Reconciler) create() error {
 	klog.Infof("%s: creating machine", r.machine.Name)
 
+	if instances, err := r.getMachineInstances(); err == nil && len(instances) > 0 {
+		klog.Infof("%s: found existing instance %s for machine", r.machine.Name, aws.StringValue(instances[0].InstanceId))
+		// If we got here, then Exists failed to find the instance, and we were asked to create a new instance.
+		// The instance already exists, so requeue and start the reconcile again, Exists should pass now.
+		// Don't bother updating the status, Update will configure everything on the next reconcile.
+		return fmt.Errorf("%s: Possible eventual-consistency discrepancy; returning an error to requeue", r.machine.Name)
+	}
+	if r.providerStatus.InstanceID != nil && *r.providerStatus.InstanceID != "" {
+		// The instance was already created as we have an InstanceID within the status.
+		// We must not create a new instance, this is an eventual consistency issue
+		// on the AWS side.
+		return fmt.Errorf("%s: Machine was already created, InstanceID is set in providerStatus. Possible eventual-consistency discrepancy; returning an error to requeue", r.machine.Name)
+	}
+
 	if err := validateMachine(*r.machine); err != nil {
 		return fmt.Errorf("%v: failed validating machine provider spec: %w", r.machine.GetName(), err)
 	}
@@ -93,15 +107,13 @@ func (r *Reconciler) create() error {
 	}
 
 	klog.Infof("Created Machine %v", r.machine.Name)
-	if err = r.setProviderID(instance); err != nil {
-		return fmt.Errorf("failed to update machine object with providerID: %w", err)
-	}
-
-	if err = r.setMachineCloudProviderSpecifics(instance); err != nil {
-		return fmt.Errorf("failed to set machine cloud provider specifics: %w", err)
-	}
-
 	r.machineScope.setProviderStatus(instance, conditionSuccess())
+	// DO NOT set addresses on the first pass.
+	// If we set addresses, the machine controller implies that the machine is provisioned.
+	// We remove them here so that we get a chance to requeue when there is a delay in the
+	// instance appearing within the API.
+	// XRef: https://github.com/openshift/machine-api-operator/blob/ce3579a54b486a12b185301aae0307dfb5443e5e/pkg/controller/machine/controller.go#L680
+	r.machine.Status.Addresses = nil
 
 	return nil
 }

--- a/pkg/actuators/machine/reconciler_test.go
+++ b/pkg/actuators/machine/reconciler_test.go
@@ -113,12 +113,13 @@ func TestAvailabilityZone(t *testing.T) {
 				placement = &ec2.Placement{AvailabilityZone: aws.String(tc.availabilityZone)}
 			}
 
+			instanceID := "i-02fcb933c5da7085c"
 			mockAWSClient.EXPECT().RunInstances(placementMatcher{placement}).Return(
 				&ec2.Reservation{
 					Instances: []*ec2.Instance{
 						{
 							ImageId:    aws.String("ami-a9acbbd6"),
-							InstanceId: aws.String("i-02fcb933c5da7085c"),
+							InstanceId: aws.String(instanceID),
 							State: &ec2.InstanceState{
 								Name: aws.String(ec2.InstanceStateNameRunning),
 							},
@@ -130,24 +131,8 @@ func TestAvailabilityZone(t *testing.T) {
 					},
 				}, nil).AnyTimes()
 
-			mockAWSClient.EXPECT().DescribeInstances(gomock.Any()).Return(
-				&ec2.DescribeInstancesOutput{
-					Reservations: []*ec2.Reservation{
-						{
-							Instances: []*ec2.Instance{
-								{
-									ImageId:    aws.String("ami-a9acbbd6"),
-									InstanceId: aws.String("i-02fcb933c5da7085c"),
-									State: &ec2.InstanceState{
-										Name: aws.String(ec2.InstanceStateNameRunning),
-										Code: aws.Int64(16),
-									},
-									LaunchTime: aws.Time(time.Now()),
-								},
-							},
-						},
-					},
-				}, nil).AnyTimes()
+			mockAWSClient.EXPECT().DescribeInstances(stubDescribeInstancesInput(instanceID)).Return(stubDescribeInstancesOutput("ami-a9acbbd6", instanceID, ec2.InstanceStateNameRunning, "192.168.0.10"), nil).AnyTimes()
+			mockAWSClient.EXPECT().DescribeInstances(gomock.Any()).Return(&ec2.DescribeInstancesOutput{}, nil).AnyTimes()
 
 			mockAWSClient.EXPECT().TerminateInstances(gomock.Any()).Return(&ec2.TerminateInstancesOutput{}, nil).AnyTimes()
 			mockAWSClient.EXPECT().RegisterInstancesWithLoadBalancer(gomock.Any()).AnyTimes()
@@ -194,14 +179,16 @@ func (m placementMatcher) String() string {
 
 func TestCreate(t *testing.T) {
 	// mock aws API calls
+	instanceID := "i-02fcb933c5da7085c"
 	mockCtrl := gomock.NewController(t)
 	mockAWSClient := mockaws.NewMockClient(mockCtrl)
 	mockAWSClient.EXPECT().DescribeSecurityGroups(gomock.Any()).Return(nil, fmt.Errorf("describeSecurityGroups error")).AnyTimes()
 	mockAWSClient.EXPECT().DescribeAvailabilityZones(gomock.Any()).Return(nil, fmt.Errorf("describeAvailabilityZones error")).AnyTimes()
 	mockAWSClient.EXPECT().DescribeImages(gomock.Any()).Return(nil, fmt.Errorf("describeImages error")).AnyTimes()
-	mockAWSClient.EXPECT().DescribeInstances(gomock.Any()).Return(stubDescribeInstancesOutput("ami-a9acbbd6", "i-02fcb933c5da7085c", ec2.InstanceStateNameRunning, "192.168.0.10"), nil).AnyTimes()
+	mockAWSClient.EXPECT().DescribeInstances(stubDescribeInstancesInput(instanceID)).Return(stubDescribeInstancesOutput("ami-a9acbbd6", instanceID, ec2.InstanceStateNameRunning, "192.168.0.10"), nil).AnyTimes()
+	mockAWSClient.EXPECT().DescribeInstances(gomock.Any()).Return(&ec2.DescribeInstancesOutput{}, nil).AnyTimes()
 	mockAWSClient.EXPECT().TerminateInstances(gomock.Any()).Return(&ec2.TerminateInstancesOutput{}, nil).AnyTimes()
-	mockAWSClient.EXPECT().RunInstances(gomock.Any()).Return(stubReservation("ami-a9acbbd6", "i-02fcb933c5da7085c", "192.168.0.10"), nil).AnyTimes()
+	mockAWSClient.EXPECT().RunInstances(gomock.Any()).Return(stubReservation("ami-a9acbbd6", instanceID, "192.168.0.10"), nil).AnyTimes()
 	mockAWSClient.EXPECT().RegisterInstancesWithLoadBalancer(gomock.Any()).Return(nil, nil).AnyTimes()
 	mockAWSClient.EXPECT().ELBv2DescribeLoadBalancers(gomock.Any()).Return(stubDescribeLoadBalancersOutput(), nil).AnyTimes()
 	mockAWSClient.EXPECT().ELBv2DescribeTargetGroups(gomock.Any()).Return(stubDescribeTargetGroupsOutput(), nil).AnyTimes()

--- a/pkg/actuators/machine/reconciler_test.go
+++ b/pkg/actuators/machine/reconciler_test.go
@@ -526,10 +526,31 @@ func TestCreate(t *testing.T) {
 			if err.Error() != tc.expectedError.Error() {
 				t.Errorf("Expected: %v, got %v", tc.expectedError, err)
 			}
-		} else {
-			if err != nil {
-				t.Errorf("reconciler was not expected to return error: %v", err)
-			}
+			// Important to return here as the rest of this test assumes a successful create
+			return
+		}
+
+		// For the rest of this test, it is assumed the create action was successful
+		if err != nil {
+			t.Errorf("reconciler was not expected to return error: %v", err)
+		}
+
+		if len(machineScope.machine.Status.Addresses) != 0 {
+			// If addresses are set, the machine controller assumes the machine is provisioned.
+			// Don't set this on create so that we can ensure a successful Exists -> Update
+			// before the machine is considered provisioned.
+			t.Errorf("Expected addresses to be empty, got: %v", machineScope.machine.Status.Addresses)
+		}
+		if machineScope.machine.Spec.ProviderID != nil {
+			// If provider ID is set, the machine controller assumes the machine is provisioned.
+			// Don't set this on create so that we can ensure a successful Exists -> Update
+			// before the machine is considered provisioned.
+			t.Errorf("Expected ProviderID not to be set by create, got: %v", machineScope.machine.Spec.ProviderID)
+		}
+		if machineScope.providerStatus.InstanceID == nil {
+			t.Errorf("Expected InstanceID to be set, but got nil")
+		} else if *machineScope.providerStatus.InstanceID != instanceID {
+			t.Errorf("Expected InstanceID: %v, got: %v", instanceID, *machineScope.providerStatus.InstanceID)
 		}
 	}
 }

--- a/pkg/actuators/machine/stubs.go
+++ b/pkg/actuators/machine/stubs.go
@@ -24,10 +24,11 @@ const (
 	awsCredentialsSecretName = "aws-credentials-secret"
 	userDataSecretName       = "aws-actuator-user-data-secret"
 
-	keyName        = "aws-actuator-key-name"
-	stubClusterID  = "aws-actuator-cluster"
-	stubAMIID      = "ami-a9acbbd6"
-	stubInstanceID = "i-02fcb933c5da7085c"
+	keyName         = "aws-actuator-key-name"
+	stubClusterID   = "aws-actuator-cluster"
+	stubMachineName = "aws-actuator-testing-machine"
+	stubAMIID       = "ami-a9acbbd6"
+	stubInstanceID  = "i-02fcb933c5da7085c"
 )
 
 const userDataBlob = `#cloud-config
@@ -108,7 +109,7 @@ func stubMachine() (*machinev1.Machine, error) {
 
 	machine := &machinev1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "aws-actuator-testing-machine",
+			Name:      stubMachineName,
 			Namespace: defaultNamespace,
 			Labels: map[string]string{
 				machinev1.MachineClusterIDLabel: stubClusterID,
@@ -297,7 +298,10 @@ func stubDescribeInstancesOutput(imageID, instanceID string, state string, priva
 							Code: aws.Int64(16),
 						},
 						LaunchTime:       aws.Time(time.Now()),
+						PublicIpAddress:  aws.String(privateIP),
 						PrivateIpAddress: aws.String(privateIP),
+						PrivateDnsName:   aws.String("privateDNS"),
+						PublicDnsName:    aws.String("publicDNS"),
 					},
 				},
 			},
@@ -308,6 +312,18 @@ func stubDescribeInstancesOutput(imageID, instanceID string, state string, priva
 func stubDescribeInstancesInput(instanceID string) *ec2.DescribeInstancesInput {
 	return &ec2.DescribeInstancesInput{
 		InstanceIds: aws.StringSlice([]string{instanceID}),
+	}
+}
+
+func stubDescribeInstancesInputFromName() *ec2.DescribeInstancesInput {
+	return &ec2.DescribeInstancesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   awsTagFilter("Name"),
+				Values: aws.StringSlice([]string{stubMachineName}),
+			},
+			clusterFilter(stubClusterID),
+		},
 	}
 }
 

--- a/pkg/actuators/machine/stubs.go
+++ b/pkg/actuators/machine/stubs.go
@@ -305,6 +305,12 @@ func stubDescribeInstancesOutput(imageID, instanceID string, state string, priva
 	}
 }
 
+func stubDescribeInstancesInput(instanceID string) *ec2.DescribeInstancesInput {
+	return &ec2.DescribeInstancesInput{
+		InstanceIds: aws.StringSlice([]string{instanceID}),
+	}
+}
+
 // StubDescribeDHCPOptions provides fake output
 func StubDescribeDHCPOptions() (*ec2.DescribeDhcpOptionsOutput, error) {
 	key := "key"

--- a/pkg/actuators/machine/suite_test.go
+++ b/pkg/actuators/machine/suite_test.go
@@ -10,6 +10,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -23,6 +24,7 @@ const (
 var (
 	k8sClient     client.Client
 	eventRecorder record.EventRecorder
+	cfg           *rest.Config
 )
 
 func TestMain(m *testing.M) {
@@ -35,7 +37,8 @@ func TestMain(m *testing.M) {
 
 	configv1.AddToScheme(scheme.Scheme)
 
-	cfg, err := testEnv.Start()
+	var err error
+	cfg, err = testEnv.Start()
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
We are seeing instances where AWS is not returning the instance we just created within a second or two of the initial creation time, returning a 400 error saying that the instance does not exist.
This makes the machine go into failed right now, and, in conjunction with an MHC, can lead to leaked machines as the instances are deleted before AWS acknowledges the existence of the Machine.

This PR is an attempt to improve this experience.
It does:

    Do not set the addresses after create - this prevents the machine controller from saying the instance is provisioned, if exists does not return the instance, it will call create again
    Before we create, we attempt exists again by looking for existing instances - if this succeeds, requeue and the next reconcile should work and call Update which corrects the status and provider ID
    If the exists fails a second time at the beginning of the create, but an instance ID has been set on the status, requeue, we can't create another instance, that would cause a leak

The only flaw in this that I can currently think of is that if an instance is terminated before Exists ever succeeds, then we will requeue forever as Exists currently just silently ignores these kinds of errors. To improve this, Exists could return a "Instance was terminated" error which we can unwrap and handle specifically, though this would need to be handled in the core Machine controller, so needs further work.

this is a cherry-pick of https://github.com/openshift/machine-api-provider-aws/pull/11