### PR TITLE
OCPBUGS-14969: Pass right SGs for IsExternallyManaged on creation

### DIFF
--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -371,7 +371,14 @@ func (s *Service) getFilteredSubnets(criteria ...*ec2.Filter) ([]*ec2.Subnet, er
 // They are considered "core" to its proper functioning.
 func (s *Service) GetCoreSecurityGroups(scope *scope.MachineScope) ([]string, error) {
 	if scope.IsExternallyManaged() {
-		return nil, nil
+		ids := make([]string, 0)
+		for _, sg := range scope.AWSMachine.Spec.AdditionalSecurityGroups {
+			if sg.ID == nil {
+				continue
+			}
+			ids = append(ids, *sg.ID)
+		}
+		return ids, nil
 	}
 
 	// These are common across both controlplane and node machines


### PR DESCRIPTION
When IsExternallyManaged we want to make sure additionalSecurityGroups are passed on creation to satisfy user intent. This also prevents the default VPC SG from silently attached to the ec2 and so deviating even more from user intent.