### PR TITLE
OCPBUGS-33170: All containers must fallback to logs on error

### DIFF
--- a/openshift/manifests/0000_30_cluster-api_04_cm.infrastructure-aws.yaml
+++ b/openshift/manifests/0000_30_cluster-api_04_cm.infrastructure-aws.yaml
@@ -659,6 +659,7 @@ data:
                 - ALL
               runAsGroup: 65532
               runAsUser: 65532
+            terminationMessagePolicy: FallbackToLogsOnError
             volumeMounts:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cert

--- a/openshift/tools/go.mod
+++ b/openshift/tools/go.mod
@@ -2,9 +2,7 @@ module tools
 
 go 1.18
 
-require github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20240304144039-3218c094afd5
-
-replace github.com/openshift/cluster-capi-operator/manifests-gen => github.com/damdo/cluster-capi-operator/manifests-gen v0.0.0-20240304153404-6e9cca43dfeb
+require github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20240502112228-a24f1aeb106b
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect

--- a/openshift/tools/go.sum
+++ b/openshift/tools/go.sum
@@ -214,8 +214,6 @@ github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7Do
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
-github.com/damdo/cluster-capi-operator/manifests-gen v0.0.0-20240304153404-6e9cca43dfeb h1:yNtCF5z77XrfoF4VNUTXSEvGZkIJm0p8ox/0XaGgUTQ=
-github.com/damdo/cluster-capi-operator/manifests-gen v0.0.0-20240304153404-6e9cca43dfeb/go.mod h1:fEXzPOnusmda/9L2GJdI/MG0c/dbpzKtMXis096fsRU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -774,6 +772,8 @@ github.com/opencontainers/runc v0.0.0-20190115041553-12f6a991201f/go.mod h1:qT5X
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
+github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20240502112228-a24f1aeb106b h1:b61ReGGIAZ83fdElH/Q3DWo9OIFHDR4I2Aubgztife0=
+github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20240502112228-a24f1aeb106b/go.mod h1:fEXzPOnusmda/9L2GJdI/MG0c/dbpzKtMXis096fsRU=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/openshift/tools/vendor/github.com/openshift/cluster-capi-operator/manifests-gen/customizations.go
+++ b/openshift/tools/vendor/github.com/openshift/cluster-capi-operator/manifests-gen/customizations.go
@@ -234,6 +234,9 @@ func customizeDeployments(obj *unstructured.Unstructured) {
 		if container.Name == "kube-rbac-proxy" {
 			container.Image = "registry.ci.openshift.org/openshift:kube-rbac-proxy"
 		}
+
+		// This helps with debugging and is enforced in OCP, see https://issues.redhat.com/browse/OCPBUGS-33170.
+		container.TerminationMessagePolicy = corev1.TerminationMessageFallbackToLogsOnError
 	}
 
 	if err := scheme.Convert(deployment, obj, nil); err != nil {

--- a/openshift/tools/vendor/modules.txt
+++ b/openshift/tools/vendor/modules.txt
@@ -193,7 +193,7 @@ github.com/munnerz/goautoneg
 # github.com/opencontainers/go-digest v1.0.0
 ## explicit; go 1.13
 github.com/opencontainers/go-digest
-# github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20240304144039-3218c094afd5 => github.com/damdo/cluster-capi-operator/manifests-gen v0.0.0-20240304153404-6e9cca43dfeb
+# github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20240502112228-a24f1aeb106b
 ## explicit; go 1.18
 github.com/openshift/cluster-capi-operator/manifests-gen
 # github.com/pelletier/go-toml/v2 v2.1.0
@@ -840,4 +840,3 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
-# github.com/openshift/cluster-capi-operator/manifests-gen => github.com/damdo/cluster-capi-operator/manifests-gen v0.0.0-20240304153404-6e9cca43dfeb


### PR DESCRIPTION
In 4.17, we are enforcing this value for all OpenShift containers via tests, link in bug comment. This helps with debugging to ensure we have logs available.

Ref: https://github.com/openshift/cluster-capi-operator/pull/172