### PR TITLE
OCPBUGS-34382: Updating ose-aws-cluster-api-controllers-container image to be consistent with ART for 4.17

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.21-openshift-4.16
+  tag: rhel-9-release-golang-1.22-openshift-4.17

--- a/openshift/Dockerfile.openshift
+++ b/openshift/Dockerfile.openshift
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
 
 WORKDIR /build
 COPY . .
@@ -7,7 +7,7 @@ RUN GO111MODULE=on CGO_ENABLED=0 GOOS=${GOOS} GOPROXY=${GOPROXY} go build \
   -o=cluster-api-provider-aws-controller-manager \
   main.go
 
-FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
 
 LABEL description="Cluster API Provider AWS Controller Manager"
 


### PR DESCRIPTION
Reconciling with https://github.com/openshift/ocp-build-data/tree/4c1326094222f9209876f06833179a1b9178faf7/images/ose-aws-cluster-api-controllers.yml