### PR TITLE
[release-4.15] OCPBUGS-39521: UPSTREAM: <carry>:Add AWSMachine fields to control vpc placement for the instance, Drop the VPC field from the AWSMachine spec, look up the VPC from the subnet instead, Add support to specify PlacementGroupPartition of placement group, Ensure Volumes and Network Interfaces are also tagged on creation

### DIFF
--- a/api/v1beta1/awscluster_conversion.go
+++ b/api/v1beta1/awscluster_conversion.go
@@ -47,6 +47,7 @@ func (src *AWSCluster) ConvertTo(dstRaw conversion.Hub) error {
 	if restored.Status.Bastion != nil {
 		dst.Status.Bastion.InstanceMetadataOptions = restored.Status.Bastion.InstanceMetadataOptions
 		dst.Status.Bastion.PlacementGroupName = restored.Status.Bastion.PlacementGroupName
+		dst.Status.Bastion.PlacementGroupPartition = restored.Status.Bastion.PlacementGroupPartition
 	}
 	dst.Spec.Partition = restored.Spec.Partition
 

--- a/api/v1beta1/awsmachine_conversion.go
+++ b/api/v1beta1/awsmachine_conversion.go
@@ -38,6 +38,8 @@ func (src *AWSMachine) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.Ignition = restored.Spec.Ignition
 	dst.Spec.InstanceMetadataOptions = restored.Spec.InstanceMetadataOptions
 	dst.Spec.PlacementGroupName = restored.Spec.PlacementGroupName
+	dst.Spec.PlacementGroupPartition = restored.Spec.PlacementGroupPartition
+	dst.Spec.SecurityGroupOverrides = restored.Spec.SecurityGroupOverrides
 
 	return nil
 }
@@ -85,6 +87,8 @@ func (r *AWSMachineTemplate) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.Template.Spec.Ignition = restored.Spec.Template.Spec.Ignition
 	dst.Spec.Template.Spec.InstanceMetadataOptions = restored.Spec.Template.Spec.InstanceMetadataOptions
 	dst.Spec.Template.Spec.PlacementGroupName = restored.Spec.Template.Spec.PlacementGroupName
+	dst.Spec.Template.Spec.PlacementGroupPartition = restored.Spec.Template.Spec.PlacementGroupPartition
+	dst.Spec.Template.Spec.SecurityGroupOverrides = restored.Spec.Template.Spec.SecurityGroupOverrides
 
 	return nil
 }

--- a/api/v1beta1/zz_generated.conversion.go
+++ b/api/v1beta1/zz_generated.conversion.go
@@ -1382,6 +1382,7 @@ func autoConvert_v1beta2_AWSMachineSpec_To_v1beta1_AWSMachineSpec(in *v1beta2.AW
 	} else {
 		out.Subnet = nil
 	}
+	// WARNING: in.SecurityGroupOverrides requires manual conversion: does not exist in peer-type
 	out.SSHKeyName = (*string)(unsafe.Pointer(in.SSHKeyName))
 	out.RootVolume = (*Volume)(unsafe.Pointer(in.RootVolume))
 	out.NonRootVolumes = *(*[]Volume)(unsafe.Pointer(&in.NonRootVolumes))
@@ -1393,6 +1394,7 @@ func autoConvert_v1beta2_AWSMachineSpec_To_v1beta1_AWSMachineSpec(in *v1beta2.AW
 	out.Ignition = (*Ignition)(unsafe.Pointer(in.Ignition))
 	out.SpotMarketOptions = (*SpotMarketOptions)(unsafe.Pointer(in.SpotMarketOptions))
 	// WARNING: in.PlacementGroupName requires manual conversion: does not exist in peer-type
+	// WARNING: in.PlacementGroupPartition requires manual conversion: does not exist in peer-type
 	out.Tenancy = in.Tenancy
 	return nil
 }
@@ -1994,6 +1996,7 @@ func autoConvert_v1beta2_Instance_To_v1beta1_Instance(in *v1beta2.Instance, out 
 	out.AvailabilityZone = in.AvailabilityZone
 	out.SpotMarketOptions = (*SpotMarketOptions)(unsafe.Pointer(in.SpotMarketOptions))
 	// WARNING: in.PlacementGroupName requires manual conversion: does not exist in peer-type
+	// WARNING: in.PlacementGroupPartition requires manual conversion: does not exist in peer-type
 	out.Tenancy = in.Tenancy
 	out.VolumeIDs = *(*[]string)(unsafe.Pointer(&in.VolumeIDs))
 	// WARNING: in.InstanceMetadataOptions requires manual conversion: does not exist in peer-type

--- a/api/v1beta2/awsmachine_types.go
+++ b/api/v1beta2/awsmachine_types.go
@@ -114,6 +114,11 @@ type AWSMachineSpec struct {
 	// +optional
 	Subnet *AWSResourceReference `json:"subnet,omitempty"`
 
+	// SecurityGroupOverrides is an optional set of security groups to use for the node.
+	// This is optional - if not provided security groups from the cluster will be used.
+	// +optional
+	SecurityGroupOverrides map[SecurityGroupRole]string `json:"securityGroupOverrides,omitempty"`
+
 	// SSHKeyName is the name of the ssh key to attach to the instance. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)
 	// +optional
 	SSHKeyName *string `json:"sshKeyName,omitempty"`
@@ -155,6 +160,14 @@ type AWSMachineSpec struct {
 	// PlacementGroupName specifies the name of the placement group in which to launch the instance.
 	// +optional
 	PlacementGroupName string `json:"placementGroupName,omitempty"`
+
+	// PlacementGroupPartition is the partition number within the placement group in which to launch the instance.
+	// This value is only valid if the placement group, referred in `PlacementGroupName`, was created with
+	// strategy set to partition.
+	// +kubebuilder:validation:Minimum:=1
+	// +kubebuilder:validation:Maximum:=7
+	// +optional
+	PlacementGroupPartition int64 `json:"placementGroupPartition,omitempty"`
 
 	// Tenancy indicates if instance should run on shared or single-tenant hardware.
 	// +optional

--- a/api/v1beta2/types.go
+++ b/api/v1beta2/types.go
@@ -198,6 +198,14 @@ type Instance struct {
 	// +optional
 	PlacementGroupName string `json:"placementGroupName,omitempty"`
 
+	// PlacementGroupPartition is the partition number within the placement group in which to launch the instance.
+	// This value is only valid if the placement group, referred in `PlacementGroupName`, was created with
+	// strategy set to partition.
+	// +kubebuilder:validation:Minimum:=1
+	// +kubebuilder:validation:Maximum:=7
+	// +optional
+	PlacementGroupPartition int64 `json:"placementGroupPartition,omitempty"`
+
 	// Tenancy indicates if instance should run on shared or single-tenant hardware.
 	// +optional
 	Tenancy string `json:"tenancy,omitempty"`

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -695,6 +695,13 @@ func (in *AWSMachineSpec) DeepCopyInto(out *AWSMachineSpec) {
 		*out = new(AWSResourceReference)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.SecurityGroupOverrides != nil {
+		in, out := &in.SecurityGroupOverrides, &out.SecurityGroupOverrides
+		*out = make(map[SecurityGroupRole]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.SSHKeyName != nil {
 		in, out := &in.SSHKeyName, &out.SSHKeyName
 		*out = new(string)

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_awsmanagedcontrolplanes.yaml
@@ -1031,6 +1031,15 @@ spec:
                     description: PlacementGroupName specifies the name of the placement
                       group in which to launch the instance.
                     type: string
+                  placementGroupPartition:
+                    description: PlacementGroupPartition is the partition number within
+                      the placement group in which to launch the instance. This value
+                      is only valid if the placement group, referred in `PlacementGroupName`,
+                      was created with strategy set to partition.
+                    format: int64
+                    maximum: 7
+                    minimum: 1
+                    type: integer
                   privateIp:
                     description: The private IPv4 address assigned to the instance.
                     type: string
@@ -2574,6 +2583,15 @@ spec:
                     description: PlacementGroupName specifies the name of the placement
                       group in which to launch the instance.
                     type: string
+                  placementGroupPartition:
+                    description: PlacementGroupPartition is the partition number within
+                      the placement group in which to launch the instance. This value
+                      is only valid if the placement group, referred in `PlacementGroupName`,
+                      was created with strategy set to partition.
+                    format: int64
+                    maximum: 7
+                    minimum: 1
+                    type: integer
                   privateIp:
                     description: The private IPv4 address assigned to the instance.
                     type: string

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusters.yaml
@@ -1588,6 +1588,15 @@ spec:
                     description: PlacementGroupName specifies the name of the placement
                       group in which to launch the instance.
                     type: string
+                  placementGroupPartition:
+                    description: PlacementGroupPartition is the partition number within
+                      the placement group in which to launch the instance. This value
+                      is only valid if the placement group, referred in `PlacementGroupName`,
+                      was created with strategy set to partition.
+                    format: int64
+                    maximum: 7
+                    minimum: 1
+                    type: integer
                   privateIp:
                     description: The private IPv4 address assigned to the instance.
                     type: string

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
@@ -775,6 +775,15 @@ spec:
                 description: PlacementGroupName specifies the name of the placement
                   group in which to launch the instance.
                 type: string
+              placementGroupPartition:
+                description: PlacementGroupPartition is the partition number within
+                  the placement group in which to launch the instance. This value
+                  is only valid if the placement group, referred in `PlacementGroupName`,
+                  was created with strategy set to partition.
+                format: int64
+                maximum: 7
+                minimum: 1
+                type: integer
               providerID:
                 description: ProviderID is the unique identifier as specified by the
                   cloud provider.
@@ -823,6 +832,13 @@ spec:
                     type: string
                 required:
                 - size
+                type: object
+              securityGroupOverrides:
+                additionalProperties:
+                  type: string
+                description: SecurityGroupOverrides is an optional set of security
+                  groups to use for the node. This is optional - if not provided security
+                  groups from the cluster will be used.
                 type: object
               spotMarketOptions:
                 description: SpotMarketOptions allows users to configure instances

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
@@ -729,6 +729,16 @@ spec:
                         description: PlacementGroupName specifies the name of the
                           placement group in which to launch the instance.
                         type: string
+                      placementGroupPartition:
+                        description: PlacementGroupPartition is the partition number
+                          within the placement group in which to launch the instance.
+                          This value is only valid if the placement group, referred
+                          in `PlacementGroupName`, was created with strategy set to
+                          partition.
+                        format: int64
+                        maximum: 7
+                        minimum: 1
+                        type: integer
                       providerID:
                         description: ProviderID is the unique identifier as specified
                           by the cloud provider.
@@ -780,6 +790,14 @@ spec:
                             type: string
                         required:
                         - size
+                        type: object
+                      securityGroupOverrides:
+                        additionalProperties:
+                          type: string
+                        description: SecurityGroupOverrides is an optional set of
+                          security groups to use for the node. This is optional -
+                          if not provided security groups from the cluster will be
+                          used.
                         type: object
                       spotMarketOptions:
                         description: SpotMarketOptions allows users to configure instances

--- a/controllers/awsmachine_controller_test.go
+++ b/controllers/awsmachine_controller_test.go
@@ -538,10 +538,6 @@ func mockedCreateInstanceCalls(m *mocks.MockEC2APIMockRecorder) {
 	m.DescribeInstances(gomock.Eq(&ec2.DescribeInstancesInput{
 		Filters: []*ec2.Filter{
 			{
-				Name:   aws.String("vpc-id"),
-				Values: aws.StringSlice([]string{"vpc-exists"}),
-			},
-			{
 				Name:   aws.String("tag:sigs.k8s.io/cluster-api-provider-aws/cluster/test-cluster"),
 				Values: aws.StringSlice([]string{"owned"}),
 			},
@@ -648,10 +644,6 @@ func mockedCreateInstanceCalls(m *mocks.MockEC2APIMockRecorder) {
 		{
 			Name:   aws.String("state"),
 			Values: aws.StringSlice([]string{"pending", "available"}),
-		},
-		{
-			Name:   aws.String("vpc-id"),
-			Values: aws.StringSlice([]string{"vpc-exists"}),
 		},
 		{
 			Name:   aws.String("subnet-id"),


### PR DESCRIPTION
UPSTREAM: <carry>:Add AWSMachine fields to control vpc placement for the instance, Drop the VPC field from the AWSMachine spec, look up the VPC from the subnet instead, Add support to specify PlacementGroupPartition of placement group, Ensure Volumes and Network Interfaces are also tagged on creation

cherry picks 

- https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4541/commits
- https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4883/commits
- https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/5057/commits