### PR TITLE
OCPBUGS-44294: [release-4.15] OSD-25934: Only tag NetworkInterfaces in RunInstances if IAM Allows It

### DIFF
--- a/controllers/awsmachine_controller_test.go
+++ b/controllers/awsmachine_controller_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/golang/mock/gomock"
@@ -595,6 +596,7 @@ func mockedCreateInstanceCalls(m *mocks.MockEC2APIMockRecorder) {
 			CreationDate: aws.String("2019-02-08T17:02:31.000Z"),
 		},
 	}}, nil)
+	m.RunInstances(gomock.Any()).Return(nil, awserr.New("DryRunOperation", "", nil))
 	m.RunInstances(gomock.Any()).Return(&ec2.Reservation{
 		Instances: []*ec2.Instance{
 			{

--- a/pkg/cloud/awserrors/errors_patch.go
+++ b/pkg/cloud/awserrors/errors_patch.go
@@ -1,0 +1,19 @@
+package awserrors
+
+// DryRunOperation is the error returned by AWS when a DryRun succeeds.
+const DryRunOperation = "DryRunOperation"
+
+// IsDryRunOperationError returns whether the error is DryRunOperation, which signifies the DryRun operation
+// was successful.
+func IsDryRunOperationError(err error) bool {
+	if code, ok := Code(err); ok {
+		switch code {
+		case DryRunOperation:
+			return true
+		default:
+			return false
+		}
+	}
+
+	return false
+}

--- a/pkg/cloud/services/ec2/bastion_test.go
+++ b/pkg/cloud/services/ec2/bastion_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
@@ -335,6 +336,8 @@ func TestServiceReconcileBastion(t *testing.T) {
 					},
 				}}, nil)
 				m.RunInstances(gomock.Any()).
+					Return(nil, awserr.New("DryRunOperation", "", nil))
+				m.RunInstances(gomock.Any()).
 					Return(&ec2.Reservation{
 						Instances: []*ec2.Instance{
 							{
@@ -566,6 +569,8 @@ func TestServiceReconcileBastionUSGOV(t *testing.T) {
 						CreationDate: aws.String("2014-02-08T17:02:31.000Z"),
 					},
 				}}, nil)
+				m.RunInstances(gomock.Any()).
+					Return(nil, awserr.New("DryRunOperation", "", nil))
 				m.RunInstances(gomock.Any()).
 					Return(&ec2.Reservation{
 						Instances: []*ec2.Instance{

--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -576,21 +576,25 @@ func (s *Service) runInstance(role string, i *infrav1.Instance) (*infrav1.Instan
 	}
 
 	if len(i.Tags) > 0 {
-		spec := &ec2.TagSpecification{ResourceType: aws.String(ec2.ResourceTypeInstance)}
-		// We need to sort keys for tests to work
-		keys := make([]string, 0, len(i.Tags))
-		for k := range i.Tags {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-		for _, key := range keys {
-			spec.Tags = append(spec.Tags, &ec2.Tag{
-				Key:   aws.String(key),
-				Value: aws.String(i.Tags[key]),
-			})
-		}
+		resources := []string{ec2.ResourceTypeInstance, ec2.ResourceTypeVolume, ec2.ResourceTypeNetworkInterface}
+		for _, r := range resources {
+			spec := &ec2.TagSpecification{ResourceType: aws.String(r)}
 
-		input.TagSpecifications = append(input.TagSpecifications, spec)
+			// We need to sort keys for tests to work
+			keys := make([]string, 0, len(i.Tags))
+			for k := range i.Tags {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			for _, key := range keys {
+				spec.Tags = append(spec.Tags, &ec2.Tag{
+					Key:   aws.String(key),
+					Value: aws.String(i.Tags[key]),
+				})
+			}
+
+			input.TagSpecifications = append(input.TagSpecifications, spec)
+		}
 	}
 
 	input.InstanceMarketOptions = getInstanceMarketOptionsRequest(i.SpotMarketOptions)

--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -613,6 +613,15 @@ func (s *Service) runInstance(role string, i *infrav1.Instance) (*infrav1.Instan
 		input.Placement.GroupName = &i.PlacementGroupName
 	}
 
+	// Test if we succeed via DryRun, otherwise remove NetworkInterface tags and try again. We may still fail
+	// for other issues even after removing NetworkInterface tags, which is captured in the later error handling below.
+	ok, err := s.runInstancesForInputAllowed(input)
+	if !ok && err != nil {
+		return nil, errors.Wrap(err, "failed to run instance")
+	} else if !ok && err == nil {
+		input.TagSpecifications = dropNetworkInterfaceTags(input)
+	}
+
 	out, err := s.EC2Client.RunInstances(input)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to run instance")

--- a/pkg/cloud/services/ec2/instances_patch.go
+++ b/pkg/cloud/services/ec2/instances_patch.go
@@ -1,0 +1,41 @@
+package ec2
+
+import (
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"k8s.io/utils/pointer"
+
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/awserrors"
+)
+
+// runInstancesForInputAllowed will set DryRun=true on the input, and test if the RunInstances call will succeed,
+// returning a bool and any additional error. Note that the aws-sdk behavior is to return an error whether the DryRun works
+// or not.
+func (s *Service) runInstancesForInputAllowed(input *ec2.RunInstancesInput) (bool, error) {
+	input.DryRun = pointer.Bool(true)
+	_, err := s.EC2Client.RunInstances(input)
+	input.DryRun = nil
+
+	// This is the success path, the API returns an error with the code 'DryRunOperation'
+	if awserrors.IsDryRunOperationError(err) {
+		s.scope.Debug("DryRun validation passed for RunInstances")
+		return true, nil
+	} else if awserrors.IsPermissionsError(err) {
+		// This is the failure path, signifying we lack permissions to perform RunInstances with the configured input
+		s.scope.Debug("DryRun validation failed for RunInstances")
+		return false, nil
+	}
+
+	// Any other error scenario means failure
+	return false, err
+}
+
+func dropNetworkInterfaceTags(input *ec2.RunInstancesInput) []*ec2.TagSpecification {
+	var tagSpecifications []*ec2.TagSpecification
+	for _, spec := range input.TagSpecifications {
+		if *spec.ResourceType != ec2.ResourceTypeNetworkInterface {
+			tagSpecifications = append(tagSpecifications, spec)
+		}
+	}
+
+	return tagSpecifications
+}

--- a/pkg/cloud/services/ec2/instances_patch_test.go
+++ b/pkg/cloud/services/ec2/instances_patch_test.go
@@ -1,0 +1,334 @@
+package ec2
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/scope"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/pkg/cloud/services/userdata"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/test/mocks"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+func TestCreateInstance_Patch(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "bootstrap-data",
+		},
+		Data: map[string][]byte{
+			"value": []byte("data"),
+		},
+	}
+
+	az := "test-zone-1a"
+
+	data := []byte("userData")
+
+	userDataCompressed, err := userdata.GzipBytes(data)
+	if err != nil {
+		t.Fatal("Failed to gzip test user data")
+	}
+
+	isUncompressedFalse := false
+
+	testcases := []struct {
+		name          string
+		machine       *clusterv1.Machine
+		machineConfig *infrav1.AWSMachineSpec
+		awsCluster    *infrav1.AWSCluster
+		expect        func(m *mocks.MockEC2APIMockRecorder)
+		check         func(instance *infrav1.Instance, err error)
+	}{
+		{
+			name: "when runInstances fails due to IAM issue in DryRun=true, we don't tag the NetworkInterface",
+			machine: &clusterv1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"set": "node"},
+				},
+				Spec: clusterv1.MachineSpec{
+					Bootstrap: clusterv1.Bootstrap{
+						DataSecretName: aws.String("bootstrap-data"),
+					},
+					FailureDomain: aws.String("us-east-1c"),
+				},
+			},
+			machineConfig: &infrav1.AWSMachineSpec{
+				AMI: infrav1.AMIReference{
+					ID: aws.String("abc"),
+				},
+				InstanceType: "m5.2xlarge",
+				Subnet: &infrav1.AWSResourceReference{
+					Filters: []infrav1.Filter{
+						{
+							Name:   "availability-zone",
+							Values: []string{"us-east-1c"},
+						},
+					},
+				},
+				UncompressedUserData: &isUncompressedFalse,
+			},
+			awsCluster: &infrav1.AWSCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: infrav1.AWSClusterSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						VPC: infrav1.VPCSpec{
+							ID: "vpc-foo",
+						},
+						Subnets: infrav1.Subnets{
+							infrav1.SubnetSpec{
+								ID:               "subnet-1",
+								AvailabilityZone: "us-east-1a",
+								IsPublic:         false,
+							},
+							infrav1.SubnetSpec{
+								ID:               "subnet-2",
+								AvailabilityZone: "us-east-1b",
+								IsPublic:         false,
+							},
+							infrav1.SubnetSpec{
+								ID:               "subnet-3",
+								AvailabilityZone: "us-east-1c",
+								IsPublic:         false,
+							},
+						},
+					},
+				},
+				Status: infrav1.AWSClusterStatus{
+					Network: infrav1.NetworkStatus{
+						SecurityGroups: map[infrav1.SecurityGroupRole]infrav1.SecurityGroup{
+							infrav1.SecurityGroupControlPlane: {
+								ID: "1",
+							},
+							infrav1.SecurityGroupNode: {
+								ID: "2",
+							},
+							infrav1.SecurityGroupLB: {
+								ID: "3",
+							},
+						},
+						APIServerELB: infrav1.LoadBalancer{
+							DNSName: "test-apiserver.us-east-1.aws",
+						},
+					},
+				},
+			},
+			expect: func(m *mocks.MockEC2APIMockRecorder) {
+				m.
+					DescribeInstanceTypes(gomock.Eq(&ec2.DescribeInstanceTypesInput{
+						InstanceTypes: []*string{
+							aws.String("m5.2xlarge"),
+						},
+					})).
+					Return(&ec2.DescribeInstanceTypesOutput{
+						InstanceTypes: []*ec2.InstanceTypeInfo{
+							{
+								ProcessorInfo: &ec2.ProcessorInfo{
+									SupportedArchitectures: []*string{
+										aws.String("x86_64"),
+									},
+								},
+							},
+						},
+					}, nil)
+				m.DescribeSubnets(gomock.Any()).Return(&ec2.DescribeSubnetsOutput{
+					Subnets: []*ec2.Subnet{
+						{
+							VpcId:               aws.String("vpc-bar"),
+							SubnetId:            aws.String("subnet-4"),
+							AvailabilityZone:    aws.String("us-east-1c"),
+							CidrBlock:           aws.String("10.0.10.0/24"),
+							MapPublicIpOnLaunch: aws.Bool(false),
+						},
+					},
+				}, nil)
+				m.
+					// First call returns UnauthorizedOperation, forcing us to drop network interface tagging
+					RunInstances(gomock.Any()).
+					Return(nil, awserr.New("UnauthorizedOperation", "", nil))
+				m.
+					// Second call to create the instance without trying to include NetworkInterface tags
+					RunInstances(&ec2.RunInstancesInput{
+						ImageId:          aws.String("abc"),
+						InstanceType:     aws.String("m5.2xlarge"),
+						KeyName:          aws.String("default"),
+						SecurityGroupIds: aws.StringSlice([]string{"2", "3"}),
+						SubnetId:         aws.String("subnet-4"),
+						TagSpecifications: []*ec2.TagSpecification{
+							{
+								ResourceType: aws.String("instance"),
+								Tags: []*ec2.Tag{
+									{
+										Key:   aws.String("MachineName"),
+										Value: aws.String("/"),
+									},
+									{
+										Key:   aws.String("Name"),
+										Value: aws.String("aws-test1"),
+									},
+									{
+										Key:   aws.String("kubernetes.io/cluster/test1"),
+										Value: aws.String("owned"),
+									},
+									{
+										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/cluster/test1"),
+										Value: aws.String("owned"),
+									},
+									{
+										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/role"),
+										Value: aws.String("node"),
+									},
+								},
+							},
+							{
+								ResourceType: aws.String("volume"),
+								Tags: []*ec2.Tag{
+									{
+										Key:   aws.String("MachineName"),
+										Value: aws.String("/"),
+									},
+									{
+										Key:   aws.String("Name"),
+										Value: aws.String("aws-test1"),
+									},
+									{
+										Key:   aws.String("kubernetes.io/cluster/test1"),
+										Value: aws.String("owned"),
+									},
+									{
+										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/cluster/test1"),
+										Value: aws.String("owned"),
+									},
+									{
+										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/role"),
+										Value: aws.String("node"),
+									},
+								},
+							},
+						},
+						UserData: aws.String(base64.StdEncoding.EncodeToString(userDataCompressed)),
+						MaxCount: aws.Int64(1),
+						MinCount: aws.Int64(1),
+					}).Return(&ec2.Reservation{
+					Instances: []*ec2.Instance{
+						{
+							State: &ec2.InstanceState{
+								Name: aws.String(ec2.InstanceStateNamePending),
+							},
+							IamInstanceProfile: &ec2.IamInstanceProfile{
+								Arn: aws.String("arn:aws:iam::123456789012:instance-profile/foo"),
+							},
+							InstanceId:     aws.String("two"),
+							InstanceType:   aws.String("m5.large"),
+							SubnetId:       aws.String("subnet-4"),
+							ImageId:        aws.String("ami-1"),
+							RootDeviceName: aws.String("device-1"),
+							BlockDeviceMappings: []*ec2.InstanceBlockDeviceMapping{
+								{
+									DeviceName: aws.String("device-1"),
+									Ebs: &ec2.EbsInstanceBlockDevice{
+										VolumeId: aws.String("volume-1"),
+									},
+								},
+							},
+							Placement: &ec2.Placement{
+								AvailabilityZone: &az,
+							},
+						},
+					},
+				}, nil)
+				m.
+					DescribeNetworkInterfaces(gomock.Any()).
+					Return(&ec2.DescribeNetworkInterfacesOutput{
+						NetworkInterfaces: []*ec2.NetworkInterface{},
+						NextToken:         nil,
+					}, nil)
+			},
+			check: func(instance *infrav1.Instance, err error) {
+				if err != nil {
+					t.Fatalf("did not expect error: %v", err)
+				}
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			ec2Mock := mocks.NewMockEC2API(mockCtrl)
+
+			scheme, err := setupScheme()
+			if err != nil {
+				t.Fatalf("failed to create scheme: %v", err)
+			}
+
+			cluster := &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test1",
+				},
+				Spec: clusterv1.ClusterSpec{
+					ClusterNetwork: &clusterv1.ClusterNetwork{
+						ServiceDomain: "cluster.local",
+						Services: &clusterv1.NetworkRanges{
+							CIDRBlocks: []string{"192.168.0.0/16"},
+						},
+						Pods: &clusterv1.NetworkRanges{
+							CIDRBlocks: []string{"192.168.0.0/16"},
+						},
+					},
+				},
+			}
+
+			machine := tc.machine
+
+			awsMachine := &infrav1.AWSMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "aws-test1",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: clusterv1.GroupVersion.String(),
+							Kind:       "Machine",
+							Name:       "test1",
+						},
+					},
+				},
+			}
+
+			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret, cluster, machine).Build()
+			clusterScope, err := scope.NewClusterScope(scope.ClusterScopeParams{
+				Client:     client,
+				Cluster:    cluster,
+				AWSCluster: tc.awsCluster,
+			})
+			if err != nil {
+				t.Fatalf("Failed to create test context: %v", err)
+			}
+
+			machineScope, err := scope.NewMachineScope(scope.MachineScopeParams{
+				Client:       client,
+				Cluster:      cluster,
+				Machine:      machine,
+				AWSMachine:   awsMachine,
+				InfraCluster: clusterScope,
+			})
+			if err != nil {
+				t.Fatalf("Failed to create test context: %v", err)
+			}
+			machineScope.AWSMachine.Spec = *tc.machineConfig
+			tc.expect(ec2Mock.EXPECT())
+
+			s := NewService(clusterScope)
+			s.EC2Client = ec2Mock
+
+			instance, err := s.CreateInstance(machineScope, data, "")
+			tc.check(instance, err)
+		})
+	}
+}

--- a/pkg/cloud/services/ec2/instances_test.go
+++ b/pkg/cloud/services/ec2/instances_test.go
@@ -2459,6 +2459,56 @@ func TestCreateInstance(t *testing.T) {
 									},
 								},
 							},
+							{
+								ResourceType: aws.String("volume"),
+								Tags: []*ec2.Tag{
+									{
+										Key:   aws.String("MachineName"),
+										Value: aws.String("default/machine-aws-test1"),
+									},
+									{
+										Key:   aws.String("Name"),
+										Value: aws.String("aws-test1"),
+									},
+									{
+										Key:   aws.String("kubernetes.io/cluster/test1"),
+										Value: aws.String("owned"),
+									},
+									{
+										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/cluster/test1"),
+										Value: aws.String("owned"),
+									},
+									{
+										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/role"),
+										Value: aws.String("node"),
+									},
+								},
+							},
+							{
+								ResourceType: aws.String("network-interface"),
+								Tags: []*ec2.Tag{
+									{
+										Key:   aws.String("MachineName"),
+										Value: aws.String("default/machine-aws-test1"),
+									},
+									{
+										Key:   aws.String("Name"),
+										Value: aws.String("aws-test1"),
+									},
+									{
+										Key:   aws.String("kubernetes.io/cluster/test1"),
+										Value: aws.String("owned"),
+									},
+									{
+										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/cluster/test1"),
+										Value: aws.String("owned"),
+									},
+									{
+										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/role"),
+										Value: aws.String("node"),
+									},
+								},
+							},
 						},
 						UserData: aws.String(base64.StdEncoding.EncodeToString(userDataCompressed)),
 					})).
@@ -2595,6 +2645,56 @@ func TestCreateInstance(t *testing.T) {
 						TagSpecifications: []*ec2.TagSpecification{
 							{
 								ResourceType: aws.String("instance"),
+								Tags: []*ec2.Tag{
+									{
+										Key:   aws.String("MachineName"),
+										Value: aws.String("default/machine-aws-test1"),
+									},
+									{
+										Key:   aws.String("Name"),
+										Value: aws.String("aws-test1"),
+									},
+									{
+										Key:   aws.String("kubernetes.io/cluster/test1"),
+										Value: aws.String("owned"),
+									},
+									{
+										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/cluster/test1"),
+										Value: aws.String("owned"),
+									},
+									{
+										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/role"),
+										Value: aws.String("node"),
+									},
+								},
+							},
+							{
+								ResourceType: aws.String("volume"),
+								Tags: []*ec2.Tag{
+									{
+										Key:   aws.String("MachineName"),
+										Value: aws.String("default/machine-aws-test1"),
+									},
+									{
+										Key:   aws.String("Name"),
+										Value: aws.String("aws-test1"),
+									},
+									{
+										Key:   aws.String("kubernetes.io/cluster/test1"),
+										Value: aws.String("owned"),
+									},
+									{
+										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/cluster/test1"),
+										Value: aws.String("owned"),
+									},
+									{
+										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/role"),
+										Value: aws.String("node"),
+									},
+								},
+							},
+							{
+								ResourceType: aws.String("network-interface"),
 								Tags: []*ec2.Tag{
 									{
 										Key:   aws.String("MachineName"),
@@ -2775,6 +2875,56 @@ func TestCreateInstance(t *testing.T) {
 						TagSpecifications: []*ec2.TagSpecification{
 							{
 								ResourceType: aws.String("instance"),
+								Tags: []*ec2.Tag{
+									{
+										Key:   aws.String("MachineName"),
+										Value: aws.String("default/machine-aws-test1"),
+									},
+									{
+										Key:   aws.String("Name"),
+										Value: aws.String("aws-test1"),
+									},
+									{
+										Key:   aws.String("kubernetes.io/cluster/test1"),
+										Value: aws.String("owned"),
+									},
+									{
+										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/cluster/test1"),
+										Value: aws.String("owned"),
+									},
+									{
+										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/role"),
+										Value: aws.String("node"),
+									},
+								},
+							},
+							{
+								ResourceType: aws.String("volume"),
+								Tags: []*ec2.Tag{
+									{
+										Key:   aws.String("MachineName"),
+										Value: aws.String("default/machine-aws-test1"),
+									},
+									{
+										Key:   aws.String("Name"),
+										Value: aws.String("aws-test1"),
+									},
+									{
+										Key:   aws.String("kubernetes.io/cluster/test1"),
+										Value: aws.String("owned"),
+									},
+									{
+										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/cluster/test1"),
+										Value: aws.String("owned"),
+									},
+									{
+										Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/role"),
+										Value: aws.String("node"),
+									},
+								},
+							},
+							{
+								ResourceType: aws.String("network-interface"),
 								Tags: []*ec2.Tag{
 									{
 										Key:   aws.String("MachineName"),

--- a/pkg/cloud/services/ec2/instances_test.go
+++ b/pkg/cloud/services/ec2/instances_test.go
@@ -376,6 +376,9 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
+				m.
+					RunInstances(gomock.Any()).
+					Return(nil, awserr.New("DryRunOperation", "", nil))
 				m. // TODO: Restore these parameters, but with the tags as well
 					RunInstances(gomock.Any()).
 					Return(&ec2.Reservation{
@@ -506,6 +509,9 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
+				m.
+					RunInstances(gomock.Any()).
+					Return(nil, awserr.New("DryRunOperation", "", nil))
 				m.
 					RunInstances(gomock.Any()).
 					Return(&ec2.Reservation{
@@ -663,6 +669,9 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
+				m.
+					RunInstances(gomock.Any()).
+					Return(nil, awserr.New("DryRunOperation", "", nil))
 				m. // TODO: Restore these parameters, but with the tags as well
 					RunInstances(gomock.Any()).
 					Return(&ec2.Reservation{
@@ -816,6 +825,9 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
+				m.
+					RunInstances(gomock.Any()).
+					Return(nil, awserr.New("DryRunOperation", "", nil))
 				m. // TODO: Restore these parameters, but with the tags as well
 					RunInstances(gomock.Any()).
 					Return(&ec2.Reservation{
@@ -970,6 +982,9 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
+				m.
+					RunInstances(gomock.Any()).
+					Return(nil, awserr.New("DryRunOperation", "", nil))
 				m. // TODO: Restore these parameters, but with the tags as well
 					RunInstances(gomock.Any()).
 					Return(&ec2.Reservation{
@@ -1100,6 +1115,9 @@ func TestCreateInstance(t *testing.T) {
 					}, nil)
 				m.
 					RunInstances(gomock.Any()).
+					Return(nil, awserr.New("DryRunOperation", "", nil))
+				m.
+					RunInstances(gomock.Any()).
 					Return(&ec2.Reservation{
 						Instances: []*ec2.Instance{
 							{
@@ -1225,6 +1243,9 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
+				m.
+					RunInstances(gomock.Any()).
+					Return(nil, awserr.New("DryRunOperation", "", nil))
 				m.
 					RunInstances(gomock.Any()).
 					Return(&ec2.Reservation{
@@ -1414,6 +1435,9 @@ func TestCreateInstance(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
+				m.
+					RunInstances(gomock.Any()).
+					Return(nil, awserr.New("DryRunOperation", "", nil))
 				m.
 					RunInstances(gomock.Any()).
 					Return(&ec2.Reservation{
@@ -1757,6 +1781,9 @@ func TestCreateInstance(t *testing.T) {
 					}, nil)
 				m.
 					RunInstances(gomock.Any()).
+					Return(nil, awserr.New("DryRunOperation", "", nil))
+				m.
+					RunInstances(gomock.Any()).
 					Return(&ec2.Reservation{
 						Instances: []*ec2.Instance{
 							{
@@ -1994,6 +2021,9 @@ func TestCreateInstance(t *testing.T) {
 					}, nil)
 				m.
 					RunInstances(gomock.Any()).
+					Return(nil, awserr.New("DryRunOperation", "", nil))
+				m.
+					RunInstances(gomock.Any()).
 					Return(&ec2.Reservation{
 						Instances: []*ec2.Instance{
 							{
@@ -2110,6 +2140,9 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
+				m.
+					RunInstances(gomock.Any()).
+					Return(nil, awserr.New("DryRunOperation", "", nil))
 				m.
 					RunInstances(gomock.Any()).
 					Return(&ec2.Reservation{
@@ -2313,6 +2346,9 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
+				m.
+					RunInstances(gomock.Any()).
+					Return(nil, awserr.New("DryRunOperation", "", nil))
 				m. // TODO: Restore these parameters, but with the tags as well
 					RunInstances(gomock.Any()).
 					Return(&ec2.Reservation{
@@ -2421,6 +2457,9 @@ func TestCreateInstance(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
+				m.
+					RunInstances(gomock.Any()).
+					Return(nil, awserr.New("DryRunOperation", "", nil))
 				m. // TODO: Restore these parameters, but with the tags as well
 					RunInstances(gomock.Eq(&ec2.RunInstancesInput{
 						ImageId:      aws.String("abc"),
@@ -2630,6 +2669,9 @@ func TestCreateInstance(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
+				m.
+					RunInstances(gomock.Any()).
+					Return(nil, awserr.New("DryRunOperation", "", nil))
 				m. // TODO: Restore these parameters, but with the tags as well
 					RunInstances(gomock.Eq(&ec2.RunInstancesInput{
 						ImageId:      aws.String("abc"),
@@ -2859,6 +2901,9 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
+				m.
+					RunInstances(gomock.Any()).
+					Return(nil, awserr.New("DryRunOperation", "", nil))
 				m. // TODO: Restore these parameters, but with the tags as well
 					RunInstances(gomock.Eq(&ec2.RunInstancesInput{
 						ImageId:      aws.String("abc"),
@@ -3074,6 +3119,9 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
+				m.
+					RunInstances(gomock.Any()).
+					Return(nil, awserr.New("DryRunOperation", "", nil))
 				m. // TODO: Restore these parameters, but with the tags as well
 					RunInstances(gomock.Any()).
 					DoAndReturn(func(input *ec2.RunInstancesInput) (*ec2.Reservation, error) {
@@ -3207,6 +3255,9 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
+				m.
+					RunInstances(gomock.Any()).
+					Return(nil, awserr.New("DryRunOperation", "", nil))
 				m. // TODO: Restore these parameters, but with the tags as well
 					RunInstances(gomock.Any()).
 					DoAndReturn(func(input *ec2.RunInstancesInput) (*ec2.Reservation, error) {
@@ -3341,6 +3392,9 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
+				m.
+					RunInstances(gomock.Any()).
+					Return(nil, awserr.New("DryRunOperation", "", nil))
 				m. // TODO: Restore these parameters, but with the tags as well
 					RunInstances(gomock.Any()).
 					DoAndReturn(func(input *ec2.RunInstancesInput) (*ec2.Reservation, error) {
@@ -3475,6 +3529,9 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
+				m.
+					RunInstances(gomock.Any()).
+					Return(nil, awserr.New("DryRunOperation", "", nil))
 				m. // TODO: Restore these parameters, but with the tags as well
 					RunInstances(gomock.Any()).
 					DoAndReturn(func(input *ec2.RunInstancesInput) (*ec2.Reservation, error) {
@@ -3606,6 +3663,9 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
+				m.
+					RunInstances(gomock.Any()).
+					Return(nil, awserr.New("DryRunOperation", "", nil))
 				m. // TODO: Restore these parameters, but with the tags as well
 					RunInstances(gomock.Any()).
 					DoAndReturn(func(input *ec2.RunInstancesInput) (*ec2.Reservation, error) {
@@ -3737,6 +3797,9 @@ func TestCreateInstance(t *testing.T) {
 							},
 						},
 					}, nil)
+				m.
+					RunInstances(gomock.Any()).
+					Return(nil, awserr.New("DryRunOperation", "", nil))
 				m. // TODO: Restore these parameters, but with the tags as well
 					RunInstances(gomock.Any()).
 					DoAndReturn(func(input *ec2.RunInstancesInput) (*ec2.Reservation, error) {
@@ -3841,6 +3904,9 @@ func TestCreateInstance(t *testing.T) {
 				},
 			},
 			expect: func(m *mocks.MockEC2APIMockRecorder) {
+				m.
+					RunInstances(gomock.Any()).
+					Return(nil, awserr.New("DryRunOperation", "", nil))
 				m. // TODO: Restore these parameters, but with the tags as well
 					RunInstances(gomock.Any()).
 					Return(&ec2.Reservation{


### PR DESCRIPTION
This is a manual cherry-pick of the following commits onto the release-4.15 branch, as I had to resolve conflicts with both. There are significant changes to behaviors, mostly around this older branch not using updated AWS SDK calls `WithContext()`.

[5c786778e66b9081de238480b18c6db9d420bd3b](https://github.com/openshift/cluster-api-provider-aws/commit/5c786778e66b9081de238480b18c6db9d420bd3b)
[7d4d4b779f65bd40891faa157fe2ab54047b86c6](https://github.com/openshift/cluster-api-provider-aws/commit/7d4d4b779f65bd40891faa157fe2ab54047b86c6)