### PR TITLE
CORS-3936: UPSTREAM: 5379: Add support for public-only networking

### DIFF
--- a/pkg/cloud/services/elb/loadbalancer.go
+++ b/pkg/cloud/services/elb/loadbalancer.go
@@ -365,7 +365,8 @@ func (s *Service) getAPIServerLBSpec(elbName string, lbSpec *infrav1.AWSLoadBala
 		// The load balancer APIs require us to only attach one subnet for each AZ.
 		subnets := s.scope.Subnets().FilterPrivate().FilterNonCni()
 
-		if scheme == infrav1.ELBSchemeInternetFacing {
+		// public-only setup has no private subnets
+		if scheme == infrav1.ELBSchemeInternetFacing || len(subnets) == 0 {
 			subnets = s.scope.Subnets().FilterPublic().FilterNonCni()
 		}
 

--- a/pkg/cloud/services/network/subnets.go
+++ b/pkg/cloud/services/network/subnets.go
@@ -187,8 +187,7 @@ func (s *Service) reconcileSubnets() error {
 	if !unmanagedVPC {
 		// Check that we need at least 1 private and 1 public subnet after we have updated the metadata
 		if len(subnets.FilterPrivate()) < 1 {
-			record.Warnf(s.scope.InfraCluster(), "FailedNoPrivateSubnet", "Expected at least 1 private subnet but got 0")
-			return errors.New("expected at least 1 private subnet but got 0")
+			record.Eventf(s.scope.InfraCluster(), "NoPrivateSubnet", "No private subnet found, this is a public-only setup")
 		}
 		if len(subnets.FilterPublic()) < 1 {
 			record.Warnf(s.scope.InfraCluster(), "FailedNoPublicSubnet", "Expected at least 1 public subnet but got 0")


### PR DESCRIPTION
Add support for public-only networking (i.e., a cluster deployed with managed-VPC while has only public subnets)

Ref: https://issues.redhat.com/browse/CORS-3936
Ref: https://issues.redhat.com/browse/DPTP-4342