### PR TITLE
ART-12521: update go mod dependency for konflux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,12 @@ bin
 envfile
 .envrc
 
+# For Konflux
+!vendor/github.com/sagikazarmark/locafero/.envrc
+!vendor/github.com/sagikazarmark/slog-shim/.envrc
+!vendor/github.com/spf13/viper/.envrc
+!vendor/github.com/subosito/gotenv/.env
+
 # kubeconfigs
 kind.kubeconfig
 minikube.kubeconfig

--- a/vendor/github.com/sagikazarmark/locafero/.envrc
+++ b/vendor/github.com/sagikazarmark/locafero/.envrc
@@ -1,0 +1,4 @@
+if ! has nix_direnv_version || ! nix_direnv_version 2.3.0; then
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.3.0/direnvrc" "sha256-Dmd+j63L84wuzgyjITIfSxSD57Tx7v51DMxVZOsiUD8="
+fi
+use flake . --impure

--- a/vendor/github.com/sagikazarmark/slog-shim/.envrc
+++ b/vendor/github.com/sagikazarmark/slog-shim/.envrc
@@ -1,0 +1,4 @@
+if ! has nix_direnv_version || ! nix_direnv_version 2.3.0; then
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.3.0/direnvrc" "sha256-Dmd+j63L84wuzgyjITIfSxSD57Tx7v51DMxVZOsiUD8="
+fi
+use flake . --impure

--- a/vendor/github.com/spf13/viper/.envrc
+++ b/vendor/github.com/spf13/viper/.envrc
@@ -1,0 +1,4 @@
+if ! has nix_direnv_version || ! nix_direnv_version 2.3.0; then
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.3.0/direnvrc" "sha256-Dmd+j63L84wuzgyjITIfSxSD57Tx7v51DMxVZOsiUD8="
+fi
+use flake . --impure

--- a/vendor/github.com/subosito/gotenv/.env
+++ b/vendor/github.com/subosito/gotenv/.env
@@ -1,0 +1,1 @@
+HELLO=world


### PR DESCRIPTION
Image build was failing on Konflux due to missing go mod dependencies.

```
2025-04-04 17:30:46,824 ERROR vendor directory changed after vendoring:
A	vendor/github.com/sagikazarmark/locafero/.envrc
A	vendor/github.com/sagikazarmark/slog-shim/.envrc
A	vendor/github.com/spf13/viper/.envrc
A	vendor/github.com/subosito/gotenv/.env
```

Konflux ignores .gitignore files since its a possible security gap. 