### PR TITLE
OCPBUGS-54567: UPSTREAM: 5374: add marketType field validation

### DIFF
--- a/api/v1beta2/awsmachine_types.go
+++ b/api/v1beta2/awsmachine_types.go
@@ -64,6 +64,8 @@ const (
 )
 
 // AWSMachineSpec defines the desired state of an Amazon EC2 instance.
+// +kubebuilder:validation:XValidation:rule="!has(self.capacityReservationId) || !has(self.marketType) || self.marketType != 'Spot'",message="capacityReservationId may not be set when marketType is Spot"
+// +kubebuilder:validation:XValidation:rule="!has(self.capacityReservationId) || !has(self.spotMarketOptions)",message="capacityReservationId cannot be set when spotMarketOptions is specified"
 type AWSMachineSpec struct {
 	// ProviderID is the unique identifier as specified by the cloud provider.
 	ProviderID *string `json:"providerID,omitempty"`

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachines.yaml
@@ -1104,6 +1104,13 @@ spec:
             required:
             - instanceType
             type: object
+            x-kubernetes-validations:
+            - message: capacityReservationId may not be set when marketType is Spot
+              rule: '!has(self.capacityReservationId) || !has(self.marketType) ||
+                self.marketType != ''Spot'''
+            - message: capacityReservationId cannot be set when spotMarketOptions
+                is specified
+              rule: '!has(self.capacityReservationId) || !has(self.spotMarketOptions)'
           status:
             description: AWSMachineStatus defines the observed state of AWSMachine.
             properties:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
@@ -1045,6 +1045,14 @@ spec:
                     required:
                     - instanceType
                     type: object
+                    x-kubernetes-validations:
+                    - message: capacityReservationId may not be set when marketType
+                        is Spot
+                      rule: '!has(self.capacityReservationId) || !has(self.marketType)
+                        || self.marketType != ''Spot'''
+                    - message: capacityReservationId cannot be set when spotMarketOptions
+                        is specified
+                      rule: '!has(self.capacityReservationId) || !has(self.spotMarketOptions)'
                 required:
                 - spec
                 type: object

--- a/exp/api/v1beta2/awsmachinepool_webhook_test.go
+++ b/exp/api/v1beta2/awsmachinepool_webhook_test.go
@@ -175,6 +175,53 @@ func TestAWSMachinePoolValidateCreate(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "with invalid MarketType provided",
+			pool: &AWSMachinePool{
+				Spec: AWSMachinePoolSpec{
+					AWSLaunchTemplate: AWSLaunchTemplate{
+						MarketType: "invalid",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "with MarketType empty value provided",
+			pool: &AWSMachinePool{
+				Spec: AWSMachinePoolSpec{
+					AWSLaunchTemplate: AWSLaunchTemplate{
+						MarketType: "",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "with MarketType Spot and CapacityReservationID value provided",
+			pool: &AWSMachinePool{
+				Spec: AWSMachinePoolSpec{
+					AWSLaunchTemplate: AWSLaunchTemplate{
+						MarketType:            infrav1.MarketTypeSpot,
+						CapacityReservationID: aws.String("cr-123"),
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "with CapacityReservationID and SpotMarketOptions value provided",
+			pool: &AWSMachinePool{
+				Spec: AWSMachinePoolSpec{
+					AWSLaunchTemplate: AWSLaunchTemplate{
+						SpotMarketOptions:     &infrav1.SpotMarketOptions{},
+						CapacityReservationID: aws.String("cr-123"),
+					},
+				},
+			},
+			wantErr: true,
+		},
+
+		{
 			name: "invalid, MarketType set to MarketTypeCapacityBlock and spotMarketOptions are specified",
 			pool: &AWSMachinePool{
 				Spec: AWSMachinePoolSpec{

--- a/openshift/infrastructure-components-openshift.yaml
+++ b/openshift/infrastructure-components-openshift.yaml
@@ -1586,6 +1586,13 @@ spec:
             required:
             - instanceType
             type: object
+            x-kubernetes-validations:
+            - message: capacityReservationId may not be set when marketType is Spot
+              rule: '!has(self.capacityReservationId) || !has(self.marketType) ||
+                self.marketType != ''Spot'''
+            - message: capacityReservationId cannot be set when spotMarketOptions
+                is specified
+              rule: '!has(self.capacityReservationId) || !has(self.spotMarketOptions)'
           status:
             description: AWSMachineStatus defines the observed state of AWSMachine.
             properties:
@@ -6189,6 +6196,14 @@ spec:
                     required:
                     - instanceType
                     type: object
+                    x-kubernetes-validations:
+                    - message: capacityReservationId may not be set when marketType
+                        is Spot
+                      rule: '!has(self.capacityReservationId) || !has(self.marketType)
+                        || self.marketType != ''Spot'''
+                    - message: capacityReservationId cannot be set when spotMarketOptions
+                        is specified
+                      rule: '!has(self.capacityReservationId) || !has(self.spotMarketOptions)'
                 required:
                 - spec
                 type: object

--- a/openshift/manifests/0000_30_cluster-api_04_cm.infrastructure-aws.yaml
+++ b/openshift/manifests/0000_30_cluster-api_04_cm.infrastructure-aws.yaml
@@ -1588,6 +1588,13 @@ data:
                 required:
                 - instanceType
                 type: object
+                x-kubernetes-validations:
+                - message: capacityReservationId may not be set when marketType is Spot
+                  rule: '!has(self.capacityReservationId) || !has(self.marketType) ||
+                    self.marketType != ''Spot'''
+                - message: capacityReservationId cannot be set when spotMarketOptions
+                    is specified
+                  rule: '!has(self.capacityReservationId) || !has(self.spotMarketOptions)'
               status:
                 description: AWSMachineStatus defines the observed state of AWSMachine.
                 properties:
@@ -6191,6 +6198,14 @@ data:
                         required:
                         - instanceType
                         type: object
+                        x-kubernetes-validations:
+                        - message: capacityReservationId may not be set when marketType
+                            is Spot
+                          rule: '!has(self.capacityReservationId) || !has(self.marketType)
+                            || self.marketType != ''Spot'''
+                        - message: capacityReservationId cannot be set when spotMarketOptions
+                            is specified
+                          rule: '!has(self.capacityReservationId) || !has(self.spotMarketOptions)'
                     required:
                     - spec
                     type: object

--- a/pkg/cloud/services/ec2/instances.go
+++ b/pkg/cloud/services/ec2/instances.go
@@ -1163,6 +1163,10 @@ func getInstanceMarketOptionsRequest(i *infrav1.Instance) (*ec2.InstanceMarketOp
 		return nil, errors.New("can't create spot capacity-blocks, remove spot market request")
 	}
 
+	if (i.MarketType == infrav1.MarketTypeSpot || i.SpotMarketOptions != nil) && i.CapacityReservationID != nil {
+		return nil, errors.New("unable to generate marketOptions for spot instance, capacityReservationID is incompatible with marketType spot and spotMarketOptions")
+	}
+
 	// Infer MarketType if not explicitly set
 	if i.SpotMarketOptions != nil && i.MarketType == "" {
 		i.MarketType = infrav1.MarketTypeSpot
@@ -1170,6 +1174,10 @@ func getInstanceMarketOptionsRequest(i *infrav1.Instance) (*ec2.InstanceMarketOp
 
 	if i.MarketType == "" {
 		i.MarketType = infrav1.MarketTypeOnDemand
+	}
+
+	if i.MarketType == infrav1.MarketTypeSpot && i.SpotMarketOptions == nil {
+		i.SpotMarketOptions = &infrav1.SpotMarketOptions{}
 	}
 
 	switch i.MarketType {

--- a/pkg/cloud/services/ec2/instances_test.go
+++ b/pkg/cloud/services/ec2/instances_test.go
@@ -5864,6 +5864,35 @@ func TestGetInstanceMarketOptionsRequest(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			name: "with marketType Spot specified",
+			instance: &infrav1.Instance{
+				MarketType: infrav1.MarketTypeSpot,
+			},
+			expectedRequest: &ec2.InstanceMarketOptionsRequest{
+				MarketType: aws.String(ec2.MarketTypeSpot),
+				SpotOptions: &ec2.SpotMarketOptions{
+					InstanceInterruptionBehavior: aws.String(ec2.InstanceInterruptionBehaviorTerminate),
+					SpotInstanceType:             aws.String(ec2.SpotInstanceTypeOneTime),
+				},
+			},
+		},
+		{
+			name: "with marketType Spot and capacityRerservationID specified",
+			instance: &infrav1.Instance{
+				MarketType:            infrav1.MarketTypeSpot,
+				CapacityReservationID: mockCapacityReservationID,
+			},
+			expectedError: errors.Errorf("unable to generate marketOptions for spot instance, capacityReservationID is incompatible with marketType spot and spotMarketOptions"),
+		},
+		{
+			name: "with spotMarketOptions and capacityRerservationID specified",
+			instance: &infrav1.Instance{
+				SpotMarketOptions:     &infrav1.SpotMarketOptions{},
+				CapacityReservationID: mockCapacityReservationID,
+			},
+			expectedError: errors.Errorf("unable to generate marketOptions for spot instance, capacityReservationID is incompatible with marketType spot and spotMarketOptions"),
+		},
+		{
 			name: "with an empty MaxPrice specified",
 			instance: &infrav1.Instance{
 				SpotMarketOptions: &infrav1.SpotMarketOptions{


### PR DESCRIPTION
- If only MarketType=Spot is specified but spotMarketType is not provided, then we must explicitly add spotMarketType to the API configuration.
- Webhook validation for the marketType field value

Ref: [https://issues.redhat.com/browse/OCPBUGS-54567](https://issues.redhat.com/browse/OCPBUGS-54567)