### PR TITLE
OCPBUGS-53003: Remove references to master branch

### DIFF
--- a/openshift/e2e-tests.sh
+++ b/openshift/e2e-tests.sh
@@ -7,12 +7,8 @@ echo "Running e2e-tests.sh"
 unset GOFLAGS
 tmp="$(mktemp -d)"
 
-if [ "${PULL_BASE_REF}" == "master" ]; then
-  # the default branch for cluster-capi-operator is main.
-  CCAPIO_BASE_REF="main"
-else
-  CCAPIO_BASE_REF=$PULL_BASE_REF
-fi
+# Default branch for both CCAPIO and this repo should be `main`.
+CCAPIO_BASE_REF=$PULL_BASE_REF
 
 echo "cloning github.com/openshift/cluster-capi-operator at branch '$CCAPIO_BASE_REF'"
 git clone --single-branch --branch="$CCAPIO_BASE_REF" --depth=1 "https://github.com/openshift/cluster-capi-operator.git" "$tmp"


### PR DESCRIPTION
This is to support renaming the master branch to main.

Counterpart to openshift/release#62705

/hold

Hold for CRT to coordinate merging of all relevant PRs.

