### PR TITLE
NO-JIRA: Revert OCPBUGS-53003: Remove references to master branch

### DIFF
--- a/openshift/e2e-tests.sh
+++ b/openshift/e2e-tests.sh
@@ -7,8 +7,12 @@ echo "Running e2e-tests.sh"
 unset GOFLAGS
 tmp="$(mktemp -d)"
 
-# Default branch for both CCAPIO and this repo should be `main`.
-CCAPIO_BASE_REF=$PULL_BASE_REF
+if [ "${PULL_BASE_REF}" == "master" ]; then
+  # the default branch for cluster-capi-operator is main.
+  CCAPIO_BASE_REF="main"
+else
+  CCAPIO_BASE_REF=$PULL_BASE_REF
+fi
 
 echo "cloning github.com/openshift/cluster-capi-operator at branch '$CCAPIO_BASE_REF'"
 git clone --single-branch --branch="$CCAPIO_BASE_REF" --depth=1 "https://github.com/openshift/cluster-capi-operator.git" "$tmp"


### PR DESCRIPTION
This reverts commit a7cb24b467beb7e05a8f4aee8e89e269a9338ad6. `openshift/release` still uses `master` as the branch name. Absence of this logic prevent rehearsals.
