### PR TITLE
NO-JIRA: Remove dead `RELEASE_DIR` ref

### DIFF
--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -3,9 +3,6 @@ TOOLS_DIR := tools
 
 include provider-version.mk
 
-$(RELEASE_DIR):
-	mkdir -p $(RELEASE_DIR)/
-
 MANIFESTS_GEN := go run ./vendor/github.com/openshift/cluster-capi-operator/manifests-gen/
 
 .PHONY: verify
@@ -21,7 +18,7 @@ update-manifests-gen:
 	cd tools && go get github.com/openshift/cluster-capi-operator/manifests-gen && go mod tidy && go mod vendor
 
 .PHONY: ocp-manifests
-ocp-manifests: $(RELEASE_DIR) ## Builds openshift specific manifests
+ocp-manifests: ## Builds openshift specific manifests
 	# Generate provider manifests.
 	cd tools && $(MANIFESTS_GEN) --manifests-path "../capi-operator-manifests" --kustomize-dir="../../openshift" \
 		--name cluster-api-provider-aws \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Simplified the OpenShift manifest generation workflow by removing unnecessary prerequisite dependencies.
* Enhanced manifest configuration capabilities with additional parameters for installation ordering, resource attributes, image reference management, platform specifications, and resource protection settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->