### PR TITLE
OCPCLOUD-3359: Add TLS substitutions

### DIFF
--- a/openshift/capi-operator-manifests/default/manifests.yaml
+++ b/openshift/capi-operator-manifests/default/manifests.yaml
@@ -409,6 +409,8 @@ spec:
         - --v=${CAPA_LOGLEVEL:=0}
         - --diagnostics-address=${CAPA_DIAGNOSTICS_ADDRESS:=:8443}
         - --insecure-diagnostics=${CAPA_INSECURE_DIAGNOSTICS:=false}
+        - --tls-min-version=${TLS_MIN_VERSION}
+        - --tls-cipher-suites=${TLS_CIPHER_SUITES}
         env:
         - name: AWS_SHARED_CREDENTIALS_FILE
           value: /home/.aws/credentials

--- a/openshift/kustomization.yaml
+++ b/openshift/kustomization.yaml
@@ -21,3 +21,15 @@ patches:
   patch: |-
     - op: remove
       path: /metadata/annotations/${AWS_CONTROLLER_IAM_ROLE~1#arn~1eks.amazonaws.com~1role-arn
+
+# Add TLS configuration args (substituted by cluster-capi-operator revisiongenerator)
+- target:
+    kind: Deployment
+    name: capa-controller-manager
+  patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: "--tls-min-version=${TLS_MIN_VERSION}"
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: "--tls-cipher-suites=${TLS_CIPHER_SUITES}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Operator container startup now includes two configurable TLS parameters exposed as command-line arguments: minimum TLS version and cipher suites. These settings can be provided at deployment time and will affect the TLS negotiation behavior of the operator process, allowing administrators to control allowed protocol versions and ciphers without changing binaries or image contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->