### PR TITLE
NO-JIRA: Update manifests generator

### DIFF
--- a/openshift/capi-operator-manifests/default/manifests.yaml
+++ b/openshift/capi-operator-manifests/default/manifests.yaml
@@ -383,6 +383,7 @@ spec:
     metadata:
       annotations:
         iam.amazonaws.com/role: ${AWS_CONTROLLER_IAM_ROLE:=""}
+        openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         cluster.x-k8s.io/provider: infrastructure-aws

--- a/openshift/tools/go.mod
+++ b/openshift/tools/go.mod
@@ -2,7 +2,7 @@ module tools
 
 go 1.25.0
 
-require github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260427143055-068bfdc8559d
+require github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260429150927-40757eb5602c
 
 require (
 	github.com/blang/semver/v4 v4.0.0 // indirect

--- a/openshift/tools/go.sum
+++ b/openshift/tools/go.sum
@@ -95,8 +95,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/openshift/api v0.0.0-20260416105050-3c6b218b8a80 h1:r0S/yoZAI0iWo1JvoIijaIgWGWf/izg4WiV7Wrtz16k=
 github.com/openshift/api v0.0.0-20260416105050-3c6b218b8a80/go.mod h1:pyVjK0nZ4sRs4fuQVQ4rubsJdahI1PB94LnQ8sGdvxo=
-github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260427143055-068bfdc8559d h1:TwA10IGqNZec7mGXQsGXjraDk0Bt5l08OMPje+hE7YY=
-github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260427143055-068bfdc8559d/go.mod h1:mRpBhhCeqkf0GwRIVYfwlZlTqOMRfxMLxxFmltzMksY=
+github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260429150927-40757eb5602c h1:brDtyXDZ8M/6KpJ9rsXQ3KKGawgN4TeiD4NpjFvu3V4=
+github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260429150927-40757eb5602c/go.mod h1:mRpBhhCeqkf0GwRIVYfwlZlTqOMRfxMLxxFmltzMksY=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/openshift/tools/vendor/github.com/openshift/cluster-capi-operator/manifests-gen/customizations.go
+++ b/openshift/tools/vendor/github.com/openshift/cluster-capi-operator/manifests-gen/customizations.go
@@ -19,14 +19,6 @@ import (
 )
 
 var (
-	// Workload annotations are used by the workload admission webhook to modify pod
-	// resources and correctly schedule them while also pinning them to specific CPUSets.
-	// See for more info:
-	// https://github.com/openshift/enhancements/blob/master/enhancements/workload-partitioning/wide-availability-workload-partitioning.md
-	openshiftWorkloadAnnotation = map[string]string{
-		"target.workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
-	}
-
 	// The expected registry for images used by the cluster-capi-operator.
 	expectedRegistry = "registry.ci.openshift.org"
 )
@@ -176,8 +168,6 @@ func customizeDeployment(obj client.Object) (client.Object, error) {
 
 	deployment.Spec.Template.Spec.PriorityClassName = "system-cluster-critical"
 
-	deployment.Spec.Template.Annotations = mergeMaps(deployment.Spec.Template.Annotations, openshiftWorkloadAnnotation)
-
 	for i := range deployment.Spec.Template.Spec.Containers {
 		container := &deployment.Spec.Template.Spec.Containers[i]
 		// Add resource requests
@@ -225,18 +215,6 @@ func replaceCertMangerServiceSecret(obj client.Object, serviceSecretNames map[st
 		anns["service.beta.openshift.io/serving-cert-secret-name"] = name
 		obj.SetAnnotations(anns)
 	}
-}
-
-// Variadic function to merge maps of like kind.
-// Note: keys of next map will override keys in previous map if previous map contains same key.
-func mergeMaps[K comparable, V any](maps ...map[K]V) map[K]V {
-	result := map[K]V{}
-	for _, m := range maps {
-		for k, v := range m {
-			result[k] = v
-		}
-	}
-	return result
 }
 
 // generateInfraClusterProtectionPolicy generates a Validating Admission Policy and Binding for protecting

--- a/openshift/tools/vendor/github.com/openshift/cluster-capi-operator/manifests-gen/kustomization.yaml
+++ b/openshift/tools/vendor/github.com/openshift/cluster-capi-operator/manifests-gen/kustomization.yaml
@@ -15,3 +15,22 @@ patches:
       name: __ignored__
       annotations:
         config.kubernetes.io/local-config: "true"
+
+# Set OpenShift pod annotations on all Deployments' pod templates.
+# - required-scc: pins the SCC (default restricted-v2, providers can override).
+#   See: https://github.com/openshift/enhancements/blob/master/enhancements/authentication/custom-scc-preemption-prevention.md
+# - workload management: enables workload partitioning scheduling.
+#   See: https://github.com/openshift/enhancements/blob/master/enhancements/workload-partitioning/wide-availability-workload-partitioning.md
+- target:
+    kind: Deployment
+  patch: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: __ignored__
+    spec:
+      template:
+        metadata:
+          annotations:
+            openshift.io/required-scc: "restricted-v2"
+            target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'

--- a/openshift/tools/vendor/modules.txt
+++ b/openshift/tools/vendor/modules.txt
@@ -111,7 +111,7 @@ github.com/opencontainers/go-digest
 # github.com/openshift/api v0.0.0-20260416105050-3c6b218b8a80
 ## explicit; go 1.25.0
 github.com/openshift/api/config/v1
-# github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260427143055-068bfdc8559d
+# github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260429150927-40757eb5602c
 ## explicit; go 1.25.0
 github.com/openshift/cluster-capi-operator/manifests-gen
 github.com/openshift/cluster-capi-operator/manifests-gen/providermetadata


### PR DESCRIPTION
## Summary
- Updates `manifests-gen` to [openshift/cluster-capi-operator#524](https://github.com/openshift/cluster-capi-operator/pull/524) which:
  - Adds the `openshift.io/required-scc: restricted-v2` annotation to provider Deployment pod templates
  - Moves the workload management annotation (`target.workload.openshift.io/management`) from Go code to a kustomize patch
- Uses a temporary `replace` directive in `go.mod` pointing to the PR fork branch — to be switched back to a direct `require` once the upstream PR merges

## TODO
- [ ] Do not merge this until [openshift/cluster-capi-operator#524](https://github.com/openshift/cluster-capi-operator/pull/524) merges. Before merging this PR, remove the replace directive in favour of pointing to the updated manifests-gen

## Test plan
- [ ] Verify generated manifests contain the new `openshift.io/required-scc: restricted-v2` annotation
- [ ] Verify the workload management annotation is still present
- [ ] CI passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Platform**
  * Added an OpenShift pod security constraint annotation to operator manifests to enforce the restricted-v2 security profile for operator deployments on OpenShift.

* **Chores**
  * Bumped a build/tooling module dependency to a newer version for improved compatibility and maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->