### PR TITLE
OCPCLOUD-3513: Verify manifests in e2e

### DIFF
--- a/openshift/e2e-tests.sh
+++ b/openshift/e2e-tests.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 
 echo "Running e2e-tests.sh"
 
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+"${SCRIPT_DIR}/e2e-verify-manifests.sh"
+
 unset GOFLAGS
 tmp="$(mktemp -d)"
 

--- a/openshift/e2e-verify-manifests.sh
+++ b/openshift/e2e-verify-manifests.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+oc get -f openshift/capi-operator-manifests/default/manifests.yaml
+
+# TODO: Update the array below when https://redhat.atlassian.net/browse/OCPCLOUD-3537 is done
+declare -a arr=("pod.not-exist.io" "svc.not-exist.io")
+
+for crd in "${arr[@]}"; do
+  echo "Checking if ${crd} exists on the cluster"
+  crd_name="$(oc get crd "$crd" --ignore-not-found -o name)"
+  if [[ -n "$crd_name" ]]; then
+    >&2 echo "Error: found unexpected CRD ${crd}!"
+    exit 1
+  fi
+done


### PR DESCRIPTION
/hold

It requires https://github.com/openshift/release/pull/80470 to get in first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end testing pipeline with new manifest verification step
  * Added validation to ensure specified Custom Resource Definitions are not present during testing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->