### PR TITLE
✨ OCPCLOUD-3513: feat: add gh-summary target to download manifests from GitHub

### DIFF
--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -1,17 +1,27 @@
 BIN_DIR := bin
 TOOLS_DIR := tools
+REPO_OWNER ?= openshift
+REPO_NAME ?= cluster-api-provider-aws
+PULL_BASE_SHA ?= main
 
 include provider-version.mk
 
 MANIFESTS_GEN := go run ./vendor/github.com/openshift/cluster-capi-operator/manifests-gen/
 
 .PHONY: verify
-verify: verify-ocp-manifests
+verify: verify-ocp-manifests verify-gh-summary
 
 .PHONY: verify-%
 verify-%: ## Ensure no diff after running some other target
 	$(MAKE) $*
 	./verify-diff.sh
+
+.PHONY: gh-summary
+gh-summary: gh-summary-default
+
+.PHONY: gh-summary-%
+gh-summary-%:
+	curl --connect-timeout 10 --max-time 120 --retry 3 -fsSL "https://raw.githubusercontent.com/$(REPO_OWNER)/$(REPO_NAME)/$(PULL_BASE_SHA)/openshift/capi-operator-manifests/$*/manifests-summary.yaml" -o "capi-operator-manifests/$*/manifests-summary.yaml"
 
 .PHONY: update-manifests-gen
 update-manifests-gen:


### PR DESCRIPTION
Add a new Makefile target that downloads the manifests-summary.yaml file for the `default` profile from a specific commit in the GitHub repository using REPO_OWNER, REPO_NAME, and PULL_BASE_SHA environment variables.

Those environment variables will be expose by [Prow](https://docs.prow.k8s.io/docs/jobs/#job-environment-variables).

The target is added into the `verify` process. It ensures that we do not modify the existing file.

/hold

Require https://github.com/openshift/cluster-api-provider-aws/pull/616 to go first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Verification now retrieves the manifest summary associated with the selected base revision before completing.
  * Added configurable repository and base-revision settings for locating the summary.
  * Improved retrieval reliability with bounded timeouts and retries.
  * Stores the downloaded summary in a consistent local location for verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->