### PR TITLE
🐛OCPBUGS-104496: UPSTREAM: <carry>: Add projected bound SA token volume for OpenShift

### DIFF
--- a/openshift/capi-operator-manifests/default/manifests.yaml
+++ b/openshift/capi-operator-manifests/default/manifests.yaml
@@ -192,6 +192,9 @@ spec:
           readOnly: true
         - mountPath: /home/.aws
           name: credentials
+        - mountPath: /var/run/secrets/openshift/serviceaccount
+          name: bound-sa-token
+          readOnly: true
       priorityClassName: system-cluster-critical
       securityContext:
         fsGroup: 1000
@@ -213,6 +216,12 @@ spec:
       - name: credentials
         secret:
           secretName: capa-manager-bootstrap-credentials
+      - name: bound-sa-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: openshift
+              path: token
 status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/openshift/kustomization.yaml
+++ b/openshift/kustomization.yaml
@@ -50,3 +50,24 @@ patches:
     - op: add
       path: /spec/template/spec/containers/0/args/-
       value: "--tls-cipher-suites=${TLS_CIPHER_SUITES}"
+
+# Add projected bound SA token volume for OpenShift OIDC/STS authentication
+- target:
+    kind: Deployment
+    name: capa-controller-manager
+  patch: |-
+    - op: add
+      path: /spec/template/spec/volumes/-
+      value:
+        name: bound-sa-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              path: token
+              audience: openshift
+    - op: add
+      path: /spec/template/spec/containers/0/volumeMounts/-
+      value:
+        name: bound-sa-token
+        mountPath: /var/run/secrets/openshift/serviceaccount
+        readOnly: true


### PR DESCRIPTION
## Description

The PR adds a projected `serviceAccountToken` volume and `volumeMount` to the controller-manager deployment via kustomize patch. This token is used for OIDC/STS authentication with AWS via `AssumeRoleWithWebIdentity`.

## Background

The https://github.com/openshift/installer/pull/10717 configured TPNU clusters to provision compute nodes with CAPI/CAPA by default. However, the signed JWT token is not mounted onto CAPA container, causing below error in [periodic-ci-openshift-cloud-credential-operator-release-5.0-periodics-e2e-aws-manual-oidc](https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/periodic-ci-openshift-cloud-credential-operator-release-5.0-periodics-e2e-aws-manual-oidc):

```log
failed to query AWSMachine instance by tags: failed to describe instances by tags: operation error
EC2: DescribeInstances, get identity: get credentials: failed to refresh cached credentials,
failed to retrieve jwt from provide source, unable to read file at /var/run/secrets/openshift/serviceaccount/token: open /var/run/secrets/openshift/serviceaccount/token: no such file or directory
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenShift service account token access for the CAPA controller manager.
  * Mounted the projected token at the standard OpenShift service account path.
  * Configured the token for the OpenShift audience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->