### PR TITLE
:seedling: NO-JIRA: Copy CredentialsRequest manifest from CAPIO

### DIFF
--- a/openshift/Dockerfile.openshift
+++ b/openshift/Dockerfile.openshift
@@ -12,6 +12,7 @@ FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
 LABEL description="Cluster API Provider AWS Controller Manager"
 
 COPY --from=builder /build/manager /manager
+COPY openshift/manifests /manifests
 COPY openshift/capi-operator-manifests /capi-operator-manifests
 
 ENTRYPOINT [ "/manager" ]

--- a/openshift/manifests/0000_30_cluster-api-provider-aws_01_credentials-request.yaml
+++ b/openshift/manifests/0000_30_cluster-api-provider-aws_01_credentials-request.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: openshift-cluster-api-aws
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    capability.openshift.io/name: CloudCredential+ClusterAPI
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-gate: "ClusterAPIMachineManagement,ClusterAPIMachineManagementAWS"
+spec:
+  serviceAccountNames:
+    - capa-controller-manager
+  secretRef:
+    name: capa-manager-bootstrap-credentials
+    namespace: openshift-cluster-api
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: AWSProviderSpec
+    statementEntries:
+      - effect: Allow
+        action:
+          - ec2:AllocateHosts
+          - ec2:CreateTags
+          - ec2:DescribeDhcpOptions
+          - ec2:DescribeImages
+          - ec2:DescribeInstances
+          - ec2:DescribeInstanceTypes
+          - ec2:DescribeSecurityGroups
+          - ec2:DescribeSubnets
+          - ec2:DescribeVpcs
+          - ec2:DescribeNetworkInterfaces
+          - ec2:DescribeNetworkInterfaceAttribute
+          - ec2:ModifyNetworkInterfaceAttribute
+          - ec2:ReleaseHosts
+          - ec2:RunInstances
+          - ec2:TerminateInstances
+          - elasticloadbalancing:DescribeLoadBalancers
+          - elasticloadbalancing:DescribeTargetGroups
+          - elasticloadbalancing:DescribeTargetHealth
+          - elasticloadbalancing:RegisterInstancesWithLoadBalancer
+          - elasticloadbalancing:RegisterTargets
+          - elasticloadbalancing:DeregisterTargets
+          - iam:PassRole
+        resource: "*"
+      - effect: Allow
+        action:
+          - kms:Decrypt
+          - kms:Encrypt
+          - kms:GenerateDataKey
+          - kms:GenerateDataKeyWithoutPlainText
+          - kms:DescribeKey
+        resource: "*"
+      - effect: Allow
+        action:
+          - kms:RevokeGrant
+          - kms:CreateGrant
+          - kms:ListGrants
+        resource: "*"
+        policyCondition:
+          "Bool":
+            "kms:GrantIsForAWSResource": true


### PR DESCRIPTION
First step of moving the CAPA CredentialsRequest from CAPIO to this repo
to enable single-PR changes.

Adds an exact copy of
0000_30_cluster-api-provider-aws_01_credentials-request.yaml from
cluster-capi-operator to CAPA's CVO manifests. It must remain identical
to the CAPIO manifest until the manifest is removed from CAPIO.

TODO:
- [ ] https://github.com/openshift/cluster-capi-operator/pull/644

/hold


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenShift runtime images now include the required deployment manifests.
  * Added AWS credentials configuration for Cluster API deployments, enabling required infrastructure, load-balancing, encryption, and role-management operations.

* **Deployment**
  * Improved OpenShift provisioning support by automatically packaging the manifests needed for AWS-based cluster management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->