### PR TITLE
[release-4.22] 🐛 OCPBUGS-112305: UPSTREAM: 6132: Persist ProviderID immediately after instance creation

### DIFF
--- a/controllers/awsmachine_controller.go
+++ b/controllers/awsmachine_controller.go
@@ -573,6 +573,11 @@ func (r *AWSMachineReconciler) reconcileNormal(ctx context.Context, machineScope
 			v1beta1conditions.MarkFalse(machineScope.AWSMachine, infrav1.InstanceReadyCondition, infrav1.InstanceProvisionFailedReason, clusterv1beta1.ConditionSeverityError, "%s", err.Error())
 			return ctrl.Result{}, err
 		}
+
+		if patchErr := machineScope.PatchObject(); patchErr != nil {
+			machineScope.Error(patchErr, "failed to patch providerID")
+			return ctrl.Result{}, patchErr
+		}
 	}
 
 	// BYO Public IPv4 Pool feature: allocates and associates an EIP to machine when PublicIP and

--- a/controllers/awsmachine_controller_test.go
+++ b/controllers/awsmachine_controller_test.go
@@ -174,6 +174,11 @@ func TestAWSMachineReconcilerIntegrationTests(t *testing.T) {
 			{infrav1.ELBAttachedCondition, corev1.ConditionTrue, "", ""},
 		})
 		g.Expect(ms.AWSMachine.Finalizers).Should(ContainElement(infrav1.MachineFinalizer))
+
+		persisted := &infrav1.AWSMachine{}
+		g.Expect(testEnv.Get(ctx, client.ObjectKeyFromObject(ms.AWSMachine), persisted)).To(Succeed())
+		g.Expect(persisted.Spec.ProviderID).ToNot(BeNil())
+		g.Expect(persisted.Spec.InstanceID).ToNot(BeNil())
 	})
 	t.Run("Should successfully reconcile control plane machine deletion", func(t *testing.T) {
 		g := NewWithT(t)


### PR DESCRIPTION
Cherry-pick of https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/6132 to release-4.22.

Prevents duplicate EC2 instances when the deferred PatchObject fails
and the next reconcile falls back to eventually-consistent tag-based
instance lookup.